### PR TITLE
'userGcM3' and 'userGcM3URL' input processing updated

### DIFF
--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -419,7 +419,17 @@ Init <- function(sim) {
   ## TODO add a data manipulation to adjust if the m3 are not given on a yearly basis.
   if (suppliedElsewhere("userGcM3", sim) | suppliedElsewhere("userGcM3URL", sim)){
 
-    if (!suppliedElsewhere("userGcM3", sim) & suppliedElsewhere("userGcM3URL", sim)){
+    if (suppliedElsewhere("userGcM3", sim)){
+
+      if (!inherits(sim$userGcM3, "data.table")){
+
+        sim$userGcM3 <- tryCatch(
+          data.table::as.data.table(sim$userGcM3),
+          error = function(e) stop(
+            "'userGcM3' could not be converted to data.table: ", e$message, call. = FALSE))
+      }
+
+    }else if (suppliedElsewhere("userGcM3URL", sim)){
 
       sim$userGcM3 <- prepInputs(url = sim$userGcM3URL,
                                  destinationPath = inputPath(sim),


### PR DESCRIPTION
- [x] Tests are passing

I've copied the object descriptions over to the work in progress `suz-metadata` branch where I am working on updating the descriptions for all the inputs.

This now allows the user to provide either `userGcM3` and `userGcM3URL` and doesn't treat it the same as the default URL: the columns aren't renamed and there is no message about the defaults being used.

Once this is merged I will send a PR to update the same block in `CBM_vol2biomass`.