### PR TITLE
Test updates

### DIFF
--- a/tests/runTests.R
+++ b/tests/runTests.R
@@ -8,16 +8,17 @@
     type = "binary",
     repos = unique(c("predictiveecology.r-universe.dev", getOption("repos"))))
 
-  # Cache Google Drive authorization
-  ## Set authorization email and cache location
-  options(
-    gargle_oauth_email = "", ## Set personal email
-    gargle_oauth_cache = "~/googledrive_oauth_cache"
-  )
+  # Authorize Google Drive
   googledrive::drive_auth()
 
-  # Set location of input data (optional)
-  # options("reproducible.inputPaths" = "~/data")
+
+## OPTIONAL: SET TEST OPTIONS ----
+
+  # Suppress warnings from calls to setupProject, simInit, and spades
+  options("spadesCBM.test.suppressWarnings" = TRUE)
+
+  # Set custom input data location
+  options("reproducible.inputPaths" = NULL)
 
 
 ## RUN ALL TESTS ----

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -55,13 +55,11 @@
       message = function(c) tryInvokeRestart("muffleMessage"),
       packageStartupMessage = function(c) tryInvokeRestart("muffleMessage"),
       warning = function(w){
-        warning = function(w){
-          if (getOption("spadesCBM.test.suppressWarnings", default = FALSE)){
+        if (getOption("spadesCBM.test.suppressWarnings", default = FALSE)){
+          tryInvokeRestart("muffleWarning")
+        }else{
+          if (grepl("^package ['\u2018]{1}[a-zA-Z0-9.]+['\u2019]{1} was built under R version [0-9.]+$", w$message)){
             tryInvokeRestart("muffleWarning")
-          }else{
-            if (grepl("^package ['\u2018]{1}[a-zA-Z0-9.]+['\u2019]{1} was built under R version [0-9.]+$", w$message)){
-              tryInvokeRestart("muffleWarning")
-            }
           }
         }
       },

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -55,8 +55,14 @@
       message = function(c) tryInvokeRestart("muffleMessage"),
       packageStartupMessage = function(c) tryInvokeRestart("muffleMessage"),
       warning = function(w){
-        if (grepl("^package ['\u2018]{1}[a-zA-Z0-9.]+['\u2019]{1} was built under R version [0-9.]+$", w$message)){
-          tryInvokeRestart("muffleWarning")
+        warning = function(w){
+          if (getOption("spadesCBM.test.suppressWarnings", default = FALSE)){
+            tryInvokeRestart("muffleWarning")
+          }else{
+            if (grepl("^package ['\u2018]{1}[a-zA-Z0-9.]+['\u2019]{1} was built under R version [0-9.]+$", w$message)){
+              tryInvokeRestart("muffleWarning")
+            }
+          }
         }
       },
       ...

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -23,13 +23,7 @@ withr::defer({
 .test_copyModule(testDirs$Rproj, testDirs$temp$modules)
 
 # Set reproducible options:
-# - Use a shared input data directory
 # - Silence messaging
-if (is.null(getOption("reproducible.inputPaths"))){
-  withr::local_options(
-    list(reproducible.inputPaths = testDirs$temp$inputs),
-    .local_envir = teardownEnv)
-}
 if (testthat::is_testing()) withr::local_options(list(reproducible.verbose = -2), .local_envir = teardownEnv)
 
 # Set Require package options:

--- a/tests/testthat/test-1-module_1-defaults.R
+++ b/tests/testthat/test-1-module_1-defaults.R
@@ -20,7 +20,8 @@ test_that("Module runs with defaults", {
       modules = "CBM_dataPrep_SK",
       paths   = list(
         projectPath = file.path(testDirs$temp$projects, "1-defaults"),
-        modulePath  = testDirs$temp$modules
+        modulePath  = testDirs$temp$modules,
+        inputPath   = testDirs$temp$inputs
         #, packagePath = testDirs$temp$libPath
       ),
       require = "testthat",

--- a/tests/testthat/test-1-module_2-withAOI.R
+++ b/tests/testthat/test-1-module_2-withAOI.R
@@ -20,7 +20,8 @@ test_that("Module runs with study AOI", {
       modules = "CBM_dataPrep_SK",
       paths   = list(
         projectPath = file.path(testDirs$temp$projects, "2-withAOI"),
-        modulePath  = testDirs$temp$modules
+        modulePath  = testDirs$temp$modules,
+        inputPath   = testDirs$temp$inputs
         #, packagePath = testDirs$temp$libPath
       ),
       require = "testthat",


### PR DESCRIPTION
2 small updates to the tests:

- [New test option: muffle warnings to setupProject, simInit, and spades](https://github.com/PredictiveEcology/CBM_dataPrep_SK/commit/5a21d1b9ad305fd0ce2f143c1377d0def92ced90)
- [project input path set explicitly in setupProject instead of with reproducible global option](e033895d7c07c8d93b5965d65a8bbde71674a715) (less faulty it seems)