### PR TITLE
Test update: test input data download simplified

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -76,11 +76,12 @@
   if (objectName == "dbPath"){
 
     # From CBM_defaults
-    reproducible::prepInputs(
-      url = "https://raw.githubusercontent.com/cat-cfs/libcbm_py/main/libcbm/resources/cbm_defaults_db/cbm_defaults_v1.2.8340.362.db",
-      targetFile = "cbm_defaults_v1.2.8340.362.db",
-      destinationPath = testDirs$temp$inputs,
-      alsoExtract = NA, fun = NA)
+    dlURL <- "https://raw.githubusercontent.com/cat-cfs/libcbm_py/main/libcbm/resources/cbm_defaults_db/cbm_defaults_v1.2.8340.362.db"
+    destPath <- file.path(testDirs$temp$inputs, basename(dlURL))
+    if (!file.exists(destPath)){
+      download.file(url = dlURL, destfile = destPath, mode = "wb", quiet = TRUE)
+    }
+    destPath
 
   }else if (objectName == "spinupSQL"){
 
@@ -95,12 +96,12 @@
   }else if (objectName == "gcMeta"){
 
     # From CBM_vol2biomass
-    reproducible::prepInputs(
-      url = "https://drive.google.com/file/d/189SFlySTt0Zs6k57-PzQMuQ29LmycDmJ/view?usp=sharing",
-      targetFile = "gcMetaEg.csv",
-      destinationPath = testDirs$temp$inputs,
-      fun = fread,
-      purge = 7)
+    dlURL <- "https://drive.google.com/file/d/189SFlySTt0Zs6k57-PzQMuQ29LmycDmJ/view?usp=sharing"
+    destPath <- file.path(testDirs$temp$inputs, "gcMetaEg.csv")
+    if (!file.exists(destPath)){
+      withr::with_options(c(googledrive_quiet = TRUE), googledrive::drive_download(dlURL, path = destPath))
+    }
+    data.table::fread(destPath)
   }
 }
 


### PR DESCRIPTION
[input test data downloaded directly instead of via reproducible:prepInputs](https://github.com/PredictiveEcology/CBM_dataPrep_SK/commit/32301dcc185b3d562113207baa389cb97afddd92)

Since this shouldn't be testing that `reproducible:prepInputs` is downloading this data correctly it makes sense to simplify this step.

e.g. downloading `dbPath` is via `reproducible:prepInputs` is done in `CBM_vol2biomass`, so if it is failing, it should be failing in a test in that module, or in the `spadesCBM` tests that include that module.