### PR TITLE
'masterRaster' default input fix

### DIFF
--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -527,7 +527,7 @@ Init <- function(sim) {
       )
 
       sim$masterRaster <- terra::classify(
-        sim$masterRaster, cbind = c(0, NA)
+        sim$masterRaster, cbind(0, NA)
       ) |> Cache()
     }
   }

--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -230,7 +230,7 @@ Init <- function(sim) {
 
   # Summarize input raster values into table
   sim$allPixDT <- data.table(
-    pixelIndex      = 1:ncell(sim$masterRaster),
+    pixelIndex      = 1:terra::ncell(sim$masterRaster),
     ages            = terra::values(sim$ageRaster)[,1],
     spatial_unit_id = terra::values(sim$spuRaster)[,1],
     gcids           = terra::values(sim$gcIndexRaster)[,1],

--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -507,9 +507,9 @@ Init <- function(sim) {
   ##study area in SK.
   #NOTE: we are providing the masterRaster in the globalCore1.R. This section is
   #being slipped.
-      if (!suppliedElsewhere("masterRaster", sim)) {
-        if (!suppliedElsewhere("masterRasterURL", sim)) {
-    sim$masterRasterURL <- extractURL("masterRaster")
+  if (!suppliedElsewhere("masterRaster", sim)) {
+    if (!suppliedElsewhere("masterRasterURL", sim)) {
+      sim$masterRasterURL <- extractURL("masterRaster")
 
       ##TODO: why is this
       message(
@@ -524,11 +524,13 @@ Init <- function(sim) {
         url = sim$masterRasterURL,
         fun = "terra::rast",
         destinationPath = inputPath(sim)
-      )|> Cache()
+      )
 
-        }
-
+      sim$masterRaster <- terra::classify(
+        sim$masterRaster, cbind = c(0, NA)
+      ) |> Cache()
     }
+  }
 
   # 2. Age raster from inventory or from user as a vector
   if(!suppliedElsewhere(sim$ages)){


### PR DESCRIPTION
[masterRaster from default URL is now reclassified so that all 0's are NA](https://github.com/PredictiveEcology/CBM_dataPrep_SK/commit/06418b3ff23a89fb185616d400593f1f58796c43)

This was being done manually in the `spadesCBM` set up but it needs to be done when using the default as well.