### PR TITLE
'gcids' removed from outputs

### DIFF
--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -142,7 +142,7 @@ defineModule(sim, list(
         pixelGroup      = "Pixel group ID",
         ages            = "Stand ages extracted from input 'ageRaster' modified such that all ages are >=3",
         spatial_unit_id = "Spatial unit IDs extracted from input 'spuRaster'",
-        gcids           = "Growth curve IDs extracted from input 'gcIndexRaster'",
+        gcids           = "Factor of growth curve IDs extracted from input 'gcIndexRaster'",
         ecozones        = "Ecozone IDs extracted from input 'ecoRaster'"
       )),
     createsOutput(
@@ -158,11 +158,6 @@ defineModule(sim, list(
       objectName = "curveID", objectClass = "character",
       desc = paste(
         "Column names in 'level3DT' that uniquely define each pixel group growth curve ID.",
-        "Required input to CBM_vol2biomass")),
-    createsOutput(
-      objectName = "gcids", objectClass = "factor",
-      desc = paste(
-        "Factor of the growth curve IDs for each pixel group.",
         "Required input to CBM_vol2biomass")),
     createsOutput(
       objectName = "ecozones", objectClass = "numeric",
@@ -301,7 +296,7 @@ Init <- function(sim) {
   sim$spatialDT <- spatialDT[, c("pixelIndex", "pixelGroup", names(pgCols)), with = FALSE]
 
 
-  ## Create sim$level3DT, sim$realAges, sim$gcids, and sim$gcids ----
+  ## Create sim$level3DT, sim$realAges, and sim$curveID ----
 
   level3DT <- unique(sim$spatialDT[, -("pixelIndex")])
   setkeyv(level3DT, "pixelGroup")
@@ -310,10 +305,9 @@ Init <- function(sim) {
   sim$curveID <- c("gcids") #, "ecozones" # "id_ecozone"
   ##TODO add to metadata -- use in multiple modules
 
-  # Create sim$gcids and sim$level3DT$gcids as a factor
-  curveID <- sim$curveID
-  sim$gcids <- factor(gcidsCreate(level3DT[, ..curveID]))
-  set(level3DT, NULL, "gcids", sim$gcids)
+  # Set sim$level3DT$gcids to be a factor
+  set(level3DT, j = "gcids",
+      value = factor(CBMutils::gcidsCreate(level3DT[, sim$curveID, with = FALSE])))
 
   # Create 'realAges' output object and set ages to be >= 3
   ## Temporary fix to CBM_core issue: https://github.com/PredictiveEcology/CBM_core/issues/1

--- a/tests/testthat/test-1-module_1-defaults.R
+++ b/tests/testthat/test-1-module_1-defaults.R
@@ -79,6 +79,9 @@ test_that("Module runs with defaults", {
     nrow(unique(simTest$spatialDT[, c("ages", "spatial_unit_id", "gcids", "ecozones")]))
   )
 
+  # Expect that 'gcids' is a factor
+  expect_true(is.factor(simTest$level3DT$gcids))
+
 
   ## Check output 'speciesPixelGroup' ----
 
@@ -101,18 +104,6 @@ test_that("Module runs with defaults", {
   expect_true(length(simTest$curveID) >= 1)
   expect_true("gcids" %in% simTest$curveID)
   expect_true(all(simTest$curveID %in% names(simTest$level3DT)))
-
-
-  ## Check output 'gcids' ----
-
-  expect_true(!is.null(simTest$gcids))
-  expect_true(inherits(simTest$gcids, "factor"))
-
-  # Check that there is 1 for every pixel group
-  expect_equal(length(simTest$gcids), nrow(simTest$level3DT))
-
-  # Check that there are no NAs
-  expect_true(all(!is.na(simTest$gcids)))
 
 
   ## Check output 'ecozones' ----

--- a/tests/testthat/test-1-module_2-withAOI.R
+++ b/tests/testthat/test-1-module_2-withAOI.R
@@ -86,6 +86,9 @@ test_that("Module runs with study AOI", {
     nrow(unique(simTest$spatialDT[, c("ages", "spatial_unit_id", "gcids", "ecozones")]))
   )
 
+  # Expect that 'gcids' is a factor
+  expect_true(is.factor(simTest$level3DT$gcids))
+
 
   ## Check output 'speciesPixelGroup' ----
 
@@ -108,18 +111,6 @@ test_that("Module runs with study AOI", {
   expect_true(length(simTest$curveID) >= 1)
   expect_true("gcids" %in% simTest$curveID)
   expect_true(all(simTest$curveID %in% names(simTest$level3DT)))
-
-
-  ## Check output 'gcids' ----
-
-  expect_true(!is.null(simTest$gcids))
-  expect_true(inherits(simTest$gcids, "factor"))
-
-  # Check that there is 1 for every pixel group
-  expect_equal(length(simTest$gcids), nrow(simTest$level3DT))
-
-  # Check that there are no NAs
-  expect_true(all(!is.na(simTest$gcids)))
 
 
   ## Check output 'ecozones' ----


### PR DESCRIPTION
'gcids' is not longer created as an output because it is no longer required in `CBM_vol2biomass` (or any other module). The tests now make sure that the `gcids` column of `level3DT` is a factor.

module tests are passing, and the `spadesCBM` tests are passing:

```
  # Set custom module locations
  options("spadesCBM.test.module.CBM_core"        = "PredictiveEcology/CBM_core@development")
  options("spadesCBM.test.module.CBM_defaults"    = "PredictiveEcology/CBM_defaults@development")
  options("spadesCBM.test.module.CBM_vol2biomass" = "PredictiveEcology/CBM_vol2biomass@development")
  options("spadesCBM.test.module.CBM_dataPrep_SK" = "suz-estella/CBM_dataPrep_SK@suz-gcids")

  # Skip recreating the Python virtual environment
  options("spadesCBM.test.virtualEnv" = FALSE)

  # Suppress warnings from calls to setupProject, simInit, and spades
  options("spadesCBM.test.suppressWarnings" = TRUE)

  ## Run 1998-2000 with AOI
  testthat::test_file("tests/testthat/test-AOI_t1-1998-2000.R")
```