### PR TITLE
mySpuDmids, historicDMtype, and lastPassDMtype update

### DIFF
--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -351,7 +351,7 @@ Init <- function(sim) {
   sim$speciesPixelGroup <- speciesPixelGroup
 
 
-  ## Create sim$mySpuDmids ----
+  ## Create sim$mySpuDmids, sim$historicDMtype, and sim$lastPassDMtype ----
 
   # Read user disturbances
   userDist <- sim$userDist
@@ -412,21 +412,14 @@ Init <- function(sim) {
       ), collapse = "; ")
     }), collapse = "\n- "))
 
+  # Set sim$historicDMtype to be wildfire
+  sim$historicDMtype <- data.table::merge.data.table(
+    sim$level3DT,
+    subset(listDist, tolower(name) == "wildfire"),
+    by = "spatial_unit_id"
+  )$disturbance_type_id
 
-  ## Create sim$historicDMtype and sim$lastPassDMtype ----
-
-  ## TODO: in Canada historic disturbance will always be fire, but the last past may
-  ## not, it could be harvest. Make this optional (the user being able to pick
-  ## the historical and last pass disturbance). If defaults are picked (fire for
-  ## both), write the user a message saying these are the defaults.
-
-  ##to remove...
-  # mySpuFires <- sim$mySpuDmids[grep("wildfire", sim$mySpuDmids$distName, ignore.case = TRUE), ]
-  # myFires <- mySpuFires[spatial_unit_id %in% unique(sim$level3DT$spatial_unit_id), ]
-  # setkey(myFires, spatial_unit_id)
-  # setkey(sim$level3DT, spatial_unit_id)
-  ###DANGER HARDCODED
-  sim$historicDMtype <- rep(sim$mySpuDmids[1,]$disturbance_type_id, dim(sim$level3DT)[1])
+  # Set sim$lastPassDMtype to be wildfire
   ## TODO: this is where it could be something else then fire
   sim$lastPassDMtype <- sim$historicDMtype
 

--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -739,8 +739,6 @@ Init <- function(sim) {
     if (suppliedElsewhere("disturbanceRastersURL", sim) &
         !identical(sim$disturbanceRastersURL, extractURL("disturbanceRasters"))){
 
-      browser()
-
       drPaths <- preProcess(
         destinationPath = inputPath(sim),
         url = sim$disturbanceRastersURL,
@@ -789,20 +787,22 @@ Init <- function(sim) {
         "User has not supplied disturbance rasters ('disturbanceRasters'). ",
         "Default for Saskatchewan will be used.")
 
-      simYears <- start(sim):end(sim)
-      if (!all(simYears %in% 1985:2011)) simYears <- 1985:2011
-      sim$disturbanceRasters <- sapply(simYears, function(simYear){
-        setNames(
-          preProcess(
-            destinationPath = inputPath(sim),
-            url         = if (simYear == simYears[[1]]) extractURL("disturbanceRasters"),
-            archive     = if (simYear != simYears[[1]]) file.path(inputPath(sim), "disturbance_testArea.zip"),
-            targetFile  = sprintf("disturbance_testArea/SaskDist_%s.grd", simYear),
-            alsoExtract = "similar",
-            fun         = NA
-          )$targetFilePath,
-          simYear)
-      })
+      # Set years where disturbance rasters are available
+      distYears <- 1985:2011
+
+      preProcess(
+        destinationPath = inputPath(sim),
+        url         = extractURL("disturbanceRasters"),
+        filename1   = "disturbance_testArea.zip",
+        targetFile  = "ReadMe.txt",
+        fun         = function() NULL,
+        alsoExtract = do.call(c, lapply(distYears, function(simYear){
+          paste0("disturbance_testArea/SaskDist_", simYear, c(".grd", ".gri", ".tif"))
+        })))
+
+      sim$disturbanceRasters <- setNames(
+        file.path(inputPath(sim), "disturbance_testArea", paste0("SaskDist_", distYears, ".grd")),
+        distYears)
     }
   }
 

--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -739,8 +739,6 @@ Init <- function(sim) {
     if (suppliedElsewhere("disturbanceRastersURL", sim) &
         !identical(sim$disturbanceRastersURL, extractURL("disturbanceRasters"))){
 
-      browser()
-
       drPaths <- preProcess(
         destinationPath = inputPath(sim),
         url = sim$disturbanceRastersURL,
@@ -791,17 +789,18 @@ Init <- function(sim) {
 
       simYears <- start(sim):end(sim)
       if (!all(simYears %in% 1985:2011)) simYears <- 1985:2011
-      sim$disturbanceRasters <- sapply(simYears, function(simYear){
-        setNames(
-          preProcess(
-            destinationPath = inputPath(sim),
-            url         = if (simYear == simYears[[1]]) extractURL("disturbanceRasters"),
-            archive     = if (simYear != simYears[[1]]) file.path(inputPath(sim), "disturbance_testArea.zip"),
-            targetFile  = sprintf("disturbance_testArea/SaskDist_%s.grd", simYear),
-            alsoExtract = "similar",
-            fun         = NA
-          )$targetFilePath,
-          simYear)
+
+      preProcess(
+        destinationPath = inputPath(sim),
+        url         = extractURL("disturbanceRasters"),
+        filename1   = "disturbance_testArea.zip",
+        targetFile  = "disturbance_testArea/SaskDist_1985.grd",
+        alsoExtract = NULL,
+        fun         = NA
+      )
+
+      sim$disturbanceRasters <- sapply(setNames(simYears, simYears), function(simYear){
+        file.path(inputPath(sim), "disturbance_testArea", sprintf("SaskDist_%s.grd", simYear))
       })
     }
   }

--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -418,7 +418,7 @@ Init <- function(sim) {
       distMatid <- c(371, 160, 26, 91)
       match1 <- listDist[disturbance_matrix_id %in% distMatid,]
       match2 <- match1[c(4,3,1,2,2),]
-      sim$mySpuDmids <- cbind(mySpuDmids, match2[,-2])
+      sim$mySpuDmids <- cbind(mySpuDmids, match2[, spatial_unit_id := NULL])
       #
       # if (mySpuDmids$distName[i] == "clearcut") {
       #   ##there is most likely more than one clearcut
@@ -738,6 +738,8 @@ Init <- function(sim) {
 
     if (suppliedElsewhere("disturbanceRastersURL", sim) &
         !identical(sim$disturbanceRastersURL, extractURL("disturbanceRasters"))){
+
+      browser()
 
       drPaths <- preProcess(
         destinationPath = inputPath(sim),

--- a/tests/testthat/test-1-module_1-defaults.R
+++ b/tests/testthat/test-1-module_1-defaults.R
@@ -29,7 +29,11 @@ test_that("Module runs with defaults", {
       dbPath     = .test_defaultInputs("dbPath"),
       spinupSQL  = .test_defaultInputs("spinupSQL"),
       species_tr = .test_defaultInputs("species_tr"),
-      gcMeta     = .test_defaultInputs("gcMeta")
+      gcMeta     = .test_defaultInputs("gcMeta"),
+
+      # Dummy input provded for 'mySpuDmids' so that reading the default 'userDist' is skipped
+      # User input is required to match the default 'userDist' with CBM-CFS3 disturbances
+      mySpuDmids = "skip_reading_default_userDist"
     )
   )
 
@@ -147,27 +151,6 @@ test_that("Module runs with defaults", {
   # Check that the real ages match the original ages where <3 now equals 3
   expect_equal(simTest$realAges[simTest$realAges >= 3], simTest$level3DT$ages[simTest$realAges >= 3])
   expect_true(all(simTest$ages[simTest$realAges < 3] == 3))
-
-
-  ## Check output 'mySpuDmids' ----
-
-  expect_true(!is.null(simTest$mySpuDmids))
-  expect_true(inherits(simTest$mySpuDmids, "data.table"))
-
-  for (colName in c(
-    "distName", "name", "description")){
-    expect_true(colName %in% names(simTest$mySpuDmids))
-    expect_true(is.character(simTest$mySpuDmids[[colName]]))
-    expect_true(all(!is.na(simTest$mySpuDmids[[colName]])))
-  }
-
-  for (colName in c(
-    "rasterID", "spatial_unit_id", "wholeStand",
-    "disturbance_type_id", "disturbance_matrix_id")){
-    expect_true(colName %in% names(simTest$mySpuDmids))
-    expect_true(is.numeric(simTest$mySpuDmids[[colName]]) | is.integer(simTest$mySpuDmids[[colName]]))
-    expect_true(all(!is.na(simTest$mySpuDmids[[colName]])))
-  }
 
 
   ## Check output 'historicDMtype' ----

--- a/tests/testthat/test-1-module_2-withAOI.R
+++ b/tests/testthat/test-1-module_2-withAOI.R
@@ -31,7 +31,15 @@ test_that("Module runs with study AOI", {
       species_tr = .test_defaultInputs("species_tr"),
       gcMeta     = .test_defaultInputs("gcMeta"),
 
-      masterRaster = terra::rast(file.path(testDirs$testdata, "masterRaster-withAOI.tif"))
+      masterRaster = terra::rast(file.path(testDirs$testdata, "masterRaster-withAOI.tif")),
+
+      # Test matching user disturbances with CBM-CFS3 disturbances
+      userDist = rbind(
+        data.frame(rasterID = 1, wholeStand = 1, distName = "Wildfire"),
+        data.frame(rasterID = 2, wholeStand = 1, distName = "Clearcut harvesting without salvage"),
+        data.frame(rasterID = 3, wholeStand = 0, distName = "Generic 20% mortality"),
+        data.frame(rasterID = 4, wholeStand = 1, distName = "Deforestation")
+      )
     )
   )
 
@@ -161,19 +169,46 @@ test_that("Module runs with study AOI", {
   expect_true(!is.null(simTest$mySpuDmids))
   expect_true(inherits(simTest$mySpuDmids, "data.table"))
 
-  for (colName in c(
-    "distName", "name", "description")){
-    expect_true(colName %in% names(simTest$mySpuDmids))
-    expect_true(is.character(simTest$mySpuDmids[[colName]]))
-    expect_true(all(!is.na(simTest$mySpuDmids[[colName]])))
-  }
+  expect_equal(nrow(simTest$mySpuDmids), 4)
 
-  for (colName in c(
-    "rasterID", "spatial_unit_id", "wholeStand",
-    "disturbance_type_id", "disturbance_matrix_id")){
-    expect_true(colName %in% names(simTest$mySpuDmids))
-    expect_true(is.numeric(simTest$mySpuDmids[[colName]]) | is.integer(simTest$mySpuDmids[[colName]]))
-    expect_true(all(!is.na(simTest$mySpuDmids[[colName]])))
+  # Check that disturbances have been matched correctly
+  rowsExpect <- rbind(
+    data.frame(
+      spatial_unit_id       = 28,
+      rasterID              = 1,
+      wholeStand            = 1,
+      distName              = "Wildfire",
+      disturbance_type_id   = 1,
+      disturbance_matrix_id = 371
+    ),
+    data.frame(
+      spatial_unit_id       = 28,
+      rasterID              = 2,
+      wholeStand            = 1,
+      distName              = "Clearcut harvesting without salvage",
+      disturbance_type_id   = 204,
+      disturbance_matrix_id = 160
+    ),
+    data.frame(
+      spatial_unit_id       = 28,
+      rasterID              = 3,
+      wholeStand            = 0,
+      distName              = "Generic 20% mortality",
+      disturbance_type_id   = 168,
+      disturbance_matrix_id = 91
+    ),
+    data.frame(
+      spatial_unit_id       = 28,
+      rasterID              = 4,
+      wholeStand            = 1,
+      distName              = "Deforestation",
+      disturbance_type_id   = 7,
+      disturbance_matrix_id = 26
+    )
+  )
+
+  for (i in 1:nrow(rowsExpect)){
+    expect_equal(nrow(merge(simTest$mySpuDmids, rowsExpect[i,], by = names(rowsExpect))), 1)
   }
 
 


### PR DESCRIPTION
# Test checks
- [x] Module tests are passing
- [x] `spadesCBM` tests are passing

# mySpuDmids update

This update makes the module flexible to spu 27 and/or 28, whereas before it was hard coded to only expect spu 28. 

This is done by joining `userDist` with the output of `CBMutils::spuDist` on columns `spatial_unit_id` and disturbance `name`, where there are two special exceptions made for name matching:
1. userDist "clearcut" can match with "Clearcut" or if not found, "Clearcut harvesting without salvage" 
2. userDist "20% mortality" can match with "20% mortality" or if not found, "Generic 20% mortality" (applies to any percent mortality)

If a match isn't found for each row of `userDist` an error is thrown.

Currently, we are returning a likely faulty result if both spu 27 and 28 are present:

```
 rasterID  distName         wholeStand   spatial_unit_id   disturbance_type_id   disturbance_matrix_id  name                    description                                                                                   
---------  --------------  -----------  ----------------  --------------------  ----------------------  ----------------------  ----------------------------------------------------------------------------------------------
        1  wildfire                  1                27                   168                      91  Generic 20% mortality   Generic 20% mortality                                                                         
        2  clearcut                  1                27                   168                      91  Generic 20% mortality   Generic 20% mortality                                                                         
        4  deforestation             1                27                     7                      26  Deforestation           Deforestation Matrix #1 (Stand Replacing). Traditionally used for all ecozones across Canada. 
        3  20% mortality             0                27                     7                      26  Deforestation           Deforestation Matrix #1 (Stand Replacing). Traditionally used for all ecozones across Canada. 
        5  20% mortality             0                27                     7                      26  Deforestation           Deforestation Matrix #1 (Stand Replacing). Traditionally used for all ecozones across Canada. 
        1  wildfire                  1                28                   168                      91  Generic 20% mortality   Generic 20% mortality                                                                         
        2  clearcut                  1                28                   168                      91  Generic 20% mortality   Generic 20% mortality                                                                         
        4  deforestation             1                28                     7                      26  Deforestation           Deforestation Matrix #1 (Stand Replacing). Traditionally used for all ecozones across Canada. 
        3  20% mortality             0                28                     7                      26  Deforestation           Deforestation Matrix #1 (Stand Replacing). Traditionally used for all ecozones across Canada. 
        5  20% mortality             0                28                     7                      26  Deforestation           Deforestation Matrix #1 (Stand Replacing). Traditionally used for all ecozones across Canada. 
```

The updated result from this PR:

```
 rasterID  distName         wholeStand   spatial_unit_id   disturbance_type_id   disturbance_matrix_id  name                                  description                                                                                   
---------  --------------  -----------  ----------------  --------------------  ----------------------  ------------------------------------  ----------------------------------------------------------------------------------------------
        1  wildfire                  1                27                     1                     378  Wildfire                              Wildfire for Saskatchewan - Boreal Shield West (NIR2011)                                      
        2  clearcut                  1                27                   204                     160  Clearcut harvesting without salvage   Default Stand Replacing Matrix for Clearcut Harvest without Salvage                           
        4  deforestation             1                27                     7                      26  Deforestation                         Deforestation Matrix #1 (Stand Replacing). Traditionally used for all ecozones across Canada. 
        3  20% mortality             0                27                   168                      91  Generic 20% mortality                 Generic 20% mortality                                                                         
        5  20% mortality             0                27                   168                      91  Generic 20% mortality                 Generic 20% mortality   
        1  wildfire                  1                28                     1                     371  Wildfire                              Wildfire for Saskatchewan - Boreal Plains (NIR2011)                                           
        2  clearcut                  1                28                   204                     160  Clearcut harvesting without salvage   Default Stand Replacing Matrix for Clearcut Harvest without Salvage                           
        4  deforestation             1                28                     7                      26  Deforestation                         Deforestation Matrix #1 (Stand Replacing). Traditionally used for all ecozones across Canada. 
        3  20% mortality             0                28                   168                      91  Generic 20% mortality                 Generic 20% mortality                                                                         
        5  20% mortality             0                28                   168                      91  Generic 20% mortality                 Generic 20% mortality                                                                         
```

# historicDMtype and lastPassDMtype update

The code has been updated to give the `CBMutils::spuDist` `disturbance_type_id` for each spatial unit where the disturbance name is "wildfire". This happens to be always `1`.

# Notes
- See these expected results for spu 28: https://github.com/PredictiveEcology/CBM_dataPrep_SK/blob/main/CBM_dataPrep_SK.R#L390
- The details removed from the comments has been saved to be added to the module metadata.
- I've made a note that it would be a good idea to add more specific tests for this somewhere, however, I'm not sure where it would best live (yet).
