### PR TITLE
Disturbance raster downloading simplified: all rasters extracted by default

### DIFF
--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -739,8 +739,6 @@ Init <- function(sim) {
     if (suppliedElsewhere("disturbanceRastersURL", sim) &
         !identical(sim$disturbanceRastersURL, extractURL("disturbanceRasters"))){
 
-      browser()
-
       drPaths <- preProcess(
         destinationPath = inputPath(sim),
         url = sim$disturbanceRastersURL,
@@ -789,20 +787,22 @@ Init <- function(sim) {
         "User has not supplied disturbance rasters ('disturbanceRasters'). ",
         "Default for Saskatchewan will be used.")
 
-      simYears <- start(sim):end(sim)
-      if (!all(simYears %in% 1985:2011)) simYears <- 1985:2011
-      sim$disturbanceRasters <- sapply(simYears, function(simYear){
-        setNames(
-          preProcess(
-            destinationPath = inputPath(sim),
-            url         = if (simYear == simYears[[1]]) extractURL("disturbanceRasters"),
-            archive     = if (simYear != simYears[[1]]) file.path(inputPath(sim), "disturbance_testArea.zip"),
-            targetFile  = sprintf("disturbance_testArea/SaskDist_%s.grd", simYear),
-            alsoExtract = "similar",
-            fun         = NA
-          )$targetFilePath,
-          simYear)
-      })
+      # Set years where disturbance rasters are available
+      distYears <- 1985:2011
+
+      preProcess(
+        destinationPath = inputPath(sim),
+        url         = extractURL("disturbanceRasters"),
+        filename1   = "disturbance_testArea.zip",
+        targetFile  = "ReadMe.txt",
+        fun         = function() NULL,
+        alsoExtract = do.call(c, lapply(distYears, function(simYear){
+          paste0("disturbance_testArea/SaskDist_", simYear, c(".grd", ".gri", ".tif"))
+        })))
+
+      sim$disturbanceRasters <- setNames(
+        file.path(inputPath(sim), "disturbance_testArea", paste0("SaskDist_", distYears, ".grd")),
+        distYears)
     }
   }
 

--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -739,8 +739,6 @@ Init <- function(sim) {
     if (suppliedElsewhere("disturbanceRastersURL", sim) &
         !identical(sim$disturbanceRastersURL, extractURL("disturbanceRasters"))){
 
-      browser()
-
       drPaths <- preProcess(
         destinationPath = inputPath(sim),
         url = sim$disturbanceRastersURL,
@@ -791,17 +789,18 @@ Init <- function(sim) {
 
       simYears <- start(sim):end(sim)
       if (!all(simYears %in% 1985:2011)) simYears <- 1985:2011
-      sim$disturbanceRasters <- sapply(simYears, function(simYear){
-        setNames(
-          preProcess(
-            destinationPath = inputPath(sim),
-            url         = if (simYear == simYears[[1]]) extractURL("disturbanceRasters"),
-            archive     = if (simYear != simYears[[1]]) file.path(inputPath(sim), "disturbance_testArea.zip"),
-            targetFile  = sprintf("disturbance_testArea/SaskDist_%s.grd", simYear),
-            alsoExtract = "similar",
-            fun         = NA
-          )$targetFilePath,
-          simYear)
+
+      preProcess(
+        destinationPath = inputPath(sim),
+        url         = extractURL("disturbanceRasters"),
+        filename1   = "disturbance_testArea.zip",
+        targetFile  = "disturbance_testArea/SaskDist_1985.grd",
+        alsoExtract = NULL,
+        fun         = NA
+      )
+
+      sim$disturbanceRasters <- sapply(setNames(simYears, simYears), function(simYear){
+        file.path(inputPath(sim), "disturbance_testArea", sprintf("SaskDist_%s.grd", simYear))
       })
     }
   }


### PR DESCRIPTION
[Disturbance raster downloading simplified: all rasters extracted by default](https://github.com/PredictiveEcology/CBM_dataPrep_SK/commit/6f372bbebfc9f313bed9528056ee7a13541627e3)

I had this set up to extract from ZIP only the disturbance rasters for the simulation years (e.g. 1998 - 2000) but the `spadesCBM` tests failed when you tried to run a simulation afterwards using with more years (e.g. 1985-2011) using the same inputs directory. It seems the additional years aren't extracted once there's already some file extracted there. I'm not sure why `preProcess` would work that way exactly, but this is a cleaner approach anyway I think!

Tests are passing in the module and in `spadesCBM`.