### PR TITLE
cache call to CBMutils::spuDistMatch

### DIFF
--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -388,7 +388,8 @@ Init <- function(sim) {
 
     userDistMatch <- CBMutils::spuDistMatch(
       userDistSpu, listDist = listDist,
-      ask = askUser)
+      ask = askUser
+    ) |> Cache()
 
     sim$mySpuDmids <- cbind(
       userDist[, setdiff(names(userDist), names(userDistMatch)), with = FALSE],


### PR DESCRIPTION
Small update to follow https://github.com/PredictiveEcology/CBM_dataPrep_SK/pull/25: The call to CBMutils::spuDistMatch is now cached so that you only have match your disturbances once.