### PR TITLE
default 'userDist' only provided if the default 'disturbanceRasters' are used

### DIFF
--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -93,20 +93,23 @@ defineModule(sim, list(
       desc = "URL for ecoRaster"),
     expectsInput(
       objectName = "disturbanceRasters", objectClass = "character",
-      desc = "Character vector of the disturbance rasters for use in simulations - defaults are the Wulder and White rasters for SK.",
-      sourceURL = "https://drive.google.com/file/d/12YnuQYytjcBej0_kdodLchPg7z9LygCt"
-    ),
+      sourceURL = "https://drive.google.com/file/d/12YnuQYytjcBej0_kdodLchPg7z9LygCt",
+      desc = paste(
+        "Required input to CBM_core.",
+        "If not specified elsewhere, the default source URL is provided.",
+        "The default is the Wulder and White disturbance rasters for SK covering 1984-2011."
+      )),
     expectsInput(
       objectName = "disturbanceRastersURL", objectClass = "character",
-      desc = "URL for disturbanceRasters"
-    ),
+      desc = "URL for disturbanceRasters"),
     expectsInput(
       objectName = "userDist", objectClass = "data.table",
       sourceURL = "https://docs.google.com/spreadsheets/d/1fOikb83aOuLlFYIn6pjmC7Jydjcy77TH",
       desc = paste(
         "Table defines the values present in the disturbance rasters.",
         "This will be matched with CBM-CFS3 disturbances to create the 'mySpuDmids' table.",
-        "Required if CBM_core input 'mySpuDmids' is not provided elsewhere."),
+        "Required if the user has provided non-default disturbanceRasters",
+        "and the CBM_core input 'mySpuDmids' is not provided elsewhere."),
       columns = c(
         rasterID   = "ID links to pixel values in the disturbance rasters",
         wholeStand = "Specifies if the whole stand is disturbed (1 = TRUE; 0 = FALSE)",
@@ -449,30 +452,14 @@ Init <- function(sim) {
   }
 
   # 2. Disturbance information
-  if (!suppliedElsewhere("userDist", sim) & !suppliedElsewhere("mySpuDmids", sim)){
+  if (!suppliedElsewhere("userDist", sim) & !suppliedElsewhere("mySpuDmids", sim)  &
+      suppliedElsewhere("userDistURL", sim)){
 
-    if (suppliedElsewhere("userDistURL", sim) &
-        !identical(sim$userDistURL, extractURL("userDist"))){
-
-      sim$userDist <- prepInputs(
-        destinationPath = inputPath(sim),
-        url = sim$userDistURL,
-        fun = data.table::fread
-      )
-
-    }else{
-
-      if (!suppliedElsewhere("userDistURL", sim, where = "user")) message(
-        "User has not supplied disturbance information ('userDist' or 'userDistURL'). ",
-        "Default for Saskatchewan will be used.")
-
-      sim$userDist <- prepInputs(
-        destinationPath = inputPath(sim),
-        url        = extractURL("userDist"),
-        targetFile = "userDist.csv",
-        fun        = data.table::fread
-      )
-    }
+    sim$userDist <- prepInputs(
+      destinationPath = inputPath(sim),
+      url = sim$userDistURL,
+      fun = data.table::fread
+    )
   }
 
   # 3. CBM admin
@@ -768,6 +755,18 @@ Init <- function(sim) {
       sim$disturbanceRasters <- setNames(
         file.path(inputPath(sim), "disturbance_testArea", paste0("SaskDist_", distYears, ".grd")),
         distYears)
+
+      # Disturbance information
+      if (!suppliedElsewhere("userDist", sim) & !suppliedElsewhere("userDistURL", sim) &
+          !suppliedElsewhere("mySpuDmids", sim)){
+
+        sim$userDist <- prepInputs(
+          destinationPath = inputPath(sim),
+          url        = extractURL("userDist"),
+          targetFile = "userDist.csv",
+          fun        = data.table::fread
+        )
+      }
     }
   }
 


### PR DESCRIPTION
@cboisvenue I wanted to see what you think about this update, and then ask a following question!

## Already done

This change makes it so that the default 'userDist' table is only read in IF the user is also using the default disturbance rasters. This would be based on the fact that the default 'userDist' table is only really valid when it is describing the values in the default disturbance rasters; if the user wants to provide their own disturbance rasters, they should also be providing their own `userDist` or `mySpuDmids` tables.

## Proposed additional change

This next Q follows our previous convo here: [mySpuDmids, historicDMtype, and lastPassDMtype update #25](https://github.com/PredictiveEcology/CBM_dataPrep_SK/pull/25)

My question is: Could adding this additional restriction around providing the default disturbance information (userDist) make it worth considering allowing the user to skip the disturbance-matching step when using the default disturbance rasters for SK? My thought process is: Since "we" are providing the disturbance rasters, maybe it makes sense for us to also provide the correct matches to their `disturbance_type_id` and `disturbance_matrix_id`. If the user provides their own, then they should have to go through the matching prompt.

My motivation for this is that currently there is no way to run all the defaults for SK without requiring user input, which makes writing tests challenging for it. To get around this in our tests, we have to provide an already-matched `mySpuDmids` table: https://github.com/PredictiveEcology/spadesCBM/blob/fd5811e6b412d339722e66d32330deec14f3a235/tests/testthat/test-SK_t1-1998-2000.R#L65. I don't think we'd want to do this for the new user "example" globals I have drafted up, but I can't write a GHA that runs the code to check for errors if it gets stopped at a prompt.

Any cons to this I'm not thinking of? If the concern is the user not understanding what the disturbances are: perhaps we could considering providing a plotting option that makes it easy for users to review their disturbance rasters.

If we do want to to this: essentially we'd just have to save the already-matched `mySpuDmids` table somewhere to be read in by the module. I believe I have the correct matches here but I think it'd be important for you double check it over! https://github.com/PredictiveEcology/spadesCBM/blob/development/tests/testthat/testdata/mySpuDmids.csv
