### PR TITLE
gcMeta is now created with `species_id` and 'sw_hw' columns; the `speciesPixelGroup` table is no longer an output

### DIFF
--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -36,21 +36,20 @@ defineModule(sim, list(
       objectName = "spinupSQL", objectClass = "dataset",
       desc = "Table containing many necesary spinup parameters", sourceURL = NA), # FROM DEFAULTS
     expectsInput(
-      objectName = "species_tr", objectClass = "dataset", desc = NA, sourceURL = NA), # FROM DEFAULTS
-    expectsInput(
       objectName = "gcMeta", objectClass = "data.frame",
-      desc = paste("Provides equivalent between provincial boundaries",
-                   "CBM-id for provincial boundaries and CBM-spatial unit ids"),
-      sourceURL =
-        "https://drive.google.com/file/d/189SFlySTt0Zs6k57-PzQMuQ29LmycDmJ/view?usp=sharing"), # FROM VOL2BIOMASS
+      sourceURL = "https://drive.google.com/file/d/189SFlySTt0Zs6k57-PzQMuQ29LmycDmJ",
+      desc = "Growth curve metadata"),
     expectsInput(
       objectName = "gcMetaURL", objectClass = "character",
       desc = "URL for gcMeta"),
     expectsInput(
+      objectName = "species_tr", objectClass = "dataset",
+      desc = paste(
+        "CBM-CFS3 'species_tr' table with columns 'species_id' and 'name'.",
+        "'Required if 'gcMeta' does not contain a 'species_id' column.")),
+    expectsInput(
       objectName = "userGcM3", objectClass = "data.frame",
-      desc = paste("User file containing:",
-                   "`gcids`, `Age`, `MerchVolume`.",
-                   "Default name `userGcM3`."),
+      desc = "Growth curve volumes by age",
       sourceURL = "https://drive.google.com/file/d/1u7o2BzPZ2Bo7hNcC8nEctNpDmp7ce84m"),
     expectsInput(
       objectName = "userGcM3URL", objectClass = "character",
@@ -75,7 +74,7 @@ defineModule(sim, list(
       sourceURL = "https://drive.google.com/file/d/1yunkaYCV2LIdqej45C4F9ir5j1An0KKr"),
     expectsInput(
       objectName = "gcIndexRasterURL", objectClass = "character",
-      desc = "URL for gcIndexRaste - optional, need this or a ageRaster"),
+      desc = "URL for gcIndexRaster"),
     expectsInput(
       objectName = "spuLocator", objectClass = "sf|SpatRaster",
       desc = paste(
@@ -159,19 +158,16 @@ defineModule(sim, list(
         ecozones        = "Ecozone IDs extracted from input 'ecoRaster'"
       )),
     createsOutput(
-      objectName = "speciesPixelGroup", objectClass = "data.frame",
-      desc = paste(
-        "Table connecting pixel groups to species IDs.",
-        "Required input to CBM_core."),
-      columns = c(
-        pixelGroup = "Pixel group ID",
-        species_id = "Species ID"
-      )),
-    createsOutput(
       objectName = "curveID", objectClass = "character",
       desc = paste(
         "Column names in 'level3DT' that uniquely define each pixel group growth curve ID.",
         "Required input to CBM_vol2biomass")),
+    createsOutput(
+      objectName = "gcMeta", objectClass = "data.frame",
+      desc = "Growth curve metadata"),
+    createsOutput(
+      objectName = "userGcM3", objectClass = "data.frame",
+      desc = "Growth curve volumes by age"),
     createsOutput(
       objectName = "ecozones", objectClass = "numeric",
       desc = paste(
@@ -391,22 +387,49 @@ Init <- function(sim) {
   sim$spatialUnits <- sim$level3DT$spatial_unit_id
 
 
-  ## Create sim$speciesPixelGroup ----
+  ## gcMeta: set 'species_id' ----
 
-  gcMeta <- sim$gcMeta
-  if (!inherits(gcMeta, "data.table")){
-    gcMeta <- tryCatch(
-      data.table::as.data.table(gcMeta),
-      error = function(e) stop(
-        "'gcMeta' could not be converted to data.table: ", e$message, call. = FALSE))
+  if (!"species_id" %in% names(sim$gcMeta)){
+
+    if (is.null(sim$species_tr)) stop("'species_tr' required to set gcMeta 'species_id")
+    if (!"name" %in% names(sim$gcMeta)) stop("gcMeta requires 'name' column to determine 'species_id'")
+
+    gcMeta <- sim$gcMeta
+    if (!inherits(gcMeta, "data.table")){
+      gcMeta <- tryCatch(
+        data.table::as.data.table(gcMeta),
+        error = function(e) stop(
+          "'gcMeta' could not be converted to data.table: ", e$message, call. = FALSE))
+    }
+
+    species_tr <- sim$species_tr
+    if (!inherits(species_tr, "data.table")){
+      species_tr <- tryCatch(
+        data.table::as.data.table(species_tr),
+        error = function(e) stop(
+          "'species_tr' could not be converted to data.table: ", e$message, call. = FALSE))
+    }
+
+    if ("locale_id" %in% names(species_tr)) species_tr <- subset(species_tr, locale_id == 1)
+
+    gcMeta[,     name_lower := trimws(tolower(name))]
+    species_tr[, name_lower := trimws(tolower(name))]
+
+    gcMeta <- merge(
+      gcMeta, species_tr[, .(name_lower, species_id)],
+      by = "name_lower", all.x = TRUE)
+
+    if (any(is.na(gcMeta$species_id))) stop(
+      "gcMeta contains species name(s) not found in species_tr: ",
+      paste(shQuote(unique(subset(gcMeta, is.na(species_id))$name)), collapse = ", "))
+
+    sim$gcMeta <- gcMeta[, c(names(sim$gcMeta), "species_id"), with = FALSE]
+    data.table::setkey(sim$gcMeta, gcids)
+
+    rm(gcMeta)
+    rm(species_tr)
+
   }
-
-  speciesPixelGroup <- gcMeta[sim$species_tr, on = .(species = name)]
-  speciesPixelGroup <- speciesPixelGroup[gcids >= 1,]
-  speciesPixelGroup <- speciesPixelGroup[,.(gcids, species_id)]
-  speciesPixelGroup <- speciesPixelGroup[sim$spatialDT, on = .(gcids=gcids)]
-  speciesPixelGroup <- unique(speciesPixelGroup[,.(pixelGroup, species_id)])
-  sim$speciesPixelGroup <- speciesPixelGroup
 
 
   ## Create sim$disturbanceMeta, sim$historicDMtype, and sim$lastPassDMtype ----
@@ -482,6 +505,38 @@ Init <- function(sim) {
 
   ## Read inputs ----
 
+  # Growth and yield metadata
+  if (!suppliedElsewhere("gcMeta", sim)){
+
+    if (suppliedElsewhere("gcMetaURL", sim) &
+        !identical(sim$gcMetaURL, extractURL("gcMeta"))){
+
+      sim$gcMeta <- prepInputs(
+        destinationPath = inputPath(sim),
+        url = sim$gcMetaURL,
+        fun = data.table::fread
+      )
+
+    }else{
+
+      if (!suppliedElsewhere("gcMetaURL", sim, where = "user")) message(
+        "User has not supplied growth curve metadata ('gcMeta' or 'gcMetaURL'). ",
+        "Default for Saskatchewan will be used.")
+
+      sim$gcMeta <- prepInputs(
+        destinationPath = inputPath(sim),
+        url        = extractURL("gcMeta"),
+        targetFile = "gcMetaEg.csv",
+        fun        = data.table::fread
+      )
+
+      sim$gcMeta$name  <- sim$gcMeta$species
+      sim$gcMeta$sw_hw <- sapply(sim$gcMeta$forest_type_id == 1, ifelse, "sw", "hw")
+
+      data.table::setkey(sim$gcMeta, gcids)
+    }
+  }
+
   # Growth and yield table
   ## TODO add a data manipulation to adjust if the m3 are not given on a yearly basis.
   if (!suppliedElsewhere("userGcM3", sim)){
@@ -508,6 +563,8 @@ Init <- function(sim) {
         fun        = data.table::fread
       )
       names(sim$userGcM3) <- c("gcids", "Age", "MerchVolume")
+
+      data.table::setkeyv(sim$userGcM3, c("gcids", "Age"))
     }
   }
 

--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -36,21 +36,20 @@ defineModule(sim, list(
       objectName = "spinupSQL", objectClass = "dataset",
       desc = "Table containing many necesary spinup parameters", sourceURL = NA), # FROM DEFAULTS
     expectsInput(
-      objectName = "species_tr", objectClass = "dataset", desc = NA, sourceURL = NA), # FROM DEFAULTS
-    expectsInput(
       objectName = "gcMeta", objectClass = "data.frame",
-      desc = paste("Provides equivalent between provincial boundaries",
-                   "CBM-id for provincial boundaries and CBM-spatial unit ids"),
-      sourceURL =
-        "https://drive.google.com/file/d/189SFlySTt0Zs6k57-PzQMuQ29LmycDmJ/view?usp=sharing"), # FROM VOL2BIOMASS
+      sourceURL = "https://drive.google.com/file/d/189SFlySTt0Zs6k57-PzQMuQ29LmycDmJ",
+      desc = "Growth curve metadata"),
     expectsInput(
       objectName = "gcMetaURL", objectClass = "character",
       desc = "URL for gcMeta"),
     expectsInput(
+      objectName = "species_tr", objectClass = "dataset",
+      desc = paste(
+        "CBM-CFS3 'species_tr' table with columns 'species_id' and 'name'.",
+        "'Required if 'gcMeta' does not contain a 'species_id' column.")),
+    expectsInput(
       objectName = "userGcM3", objectClass = "data.frame",
-      desc = paste("User file containing:",
-                   "`gcids`, `Age`, `MerchVolume`.",
-                   "Default name `userGcM3`."),
+      desc = "Growth curve volumes by age",
       sourceURL = "https://drive.google.com/file/d/1u7o2BzPZ2Bo7hNcC8nEctNpDmp7ce84m"),
     expectsInput(
       objectName = "userGcM3URL", objectClass = "character",
@@ -75,7 +74,7 @@ defineModule(sim, list(
       sourceURL = "https://drive.google.com/file/d/1yunkaYCV2LIdqej45C4F9ir5j1An0KKr"),
     expectsInput(
       objectName = "gcIndexRasterURL", objectClass = "character",
-      desc = "URL for gcIndexRaste - optional, need this or a ageRaster"),
+      desc = "URL for gcIndexRaster"),
     expectsInput(
       objectName = "spuLocator", objectClass = "sf|SpatRaster",
       desc = paste(
@@ -159,19 +158,16 @@ defineModule(sim, list(
         ecozones        = "Ecozone IDs extracted from input 'ecoRaster'"
       )),
     createsOutput(
-      objectName = "speciesPixelGroup", objectClass = "data.frame",
-      desc = paste(
-        "Table connecting pixel groups to species IDs.",
-        "Required input to CBM_core."),
-      columns = c(
-        pixelGroup = "Pixel group ID",
-        species_id = "Species ID"
-      )),
-    createsOutput(
       objectName = "curveID", objectClass = "character",
       desc = paste(
         "Column names in 'level3DT' that uniquely define each pixel group growth curve ID.",
         "Required input to CBM_vol2biomass")),
+    createsOutput(
+      objectName = "gcMeta", objectClass = "data.frame",
+      desc = "Growth curve metadata"),
+    createsOutput(
+      objectName = "userGcM3", objectClass = "data.frame",
+      desc = "Growth curve volumes by age"),
     createsOutput(
       objectName = "ecozones", objectClass = "numeric",
       desc = paste(
@@ -391,22 +387,49 @@ Init <- function(sim) {
   sim$spatialUnits <- sim$level3DT$spatial_unit_id
 
 
-  ## Create sim$speciesPixelGroup ----
+  ## gcMeta: set 'species_id' ----
 
-  gcMeta <- sim$gcMeta
-  if (!inherits(gcMeta, "data.table")){
-    gcMeta <- tryCatch(
-      data.table::as.data.table(gcMeta),
-      error = function(e) stop(
-        "'gcMeta' could not be converted to data.table: ", e$message, call. = FALSE))
+  if (!"species_id" %in% names(sim$gcMeta)){
+
+    if (is.null(sim$species_tr)) stop("'species_tr' required to set gcMeta 'species_id")
+    if (!"species" %in% names(sim$gcMeta)) stop("gcMeta requires 'species' column to determine 'species_id'")
+
+    gcMeta <- sim$gcMeta
+    if (!inherits(gcMeta, "data.table")){
+      gcMeta <- tryCatch(
+        data.table::as.data.table(gcMeta),
+        error = function(e) stop(
+          "'gcMeta' could not be converted to data.table: ", e$message, call. = FALSE))
+    }
+
+    species_tr <- sim$species_tr
+    if (!inherits(species_tr, "data.table")){
+      species_tr <- tryCatch(
+        data.table::as.data.table(species_tr),
+        error = function(e) stop(
+          "'species_tr' could not be converted to data.table: ", e$message, call. = FALSE))
+    }
+
+    if ("locale_id" %in% names(species_tr)) species_tr <- subset(species_tr, locale_id == 1)
+
+    gcMeta[,     name_lower := trimws(tolower(species))]
+    species_tr[, name_lower := trimws(tolower(name))]
+
+    gcMeta <- merge(
+      gcMeta, species_tr[, .(name_lower, species_id)],
+      by = "name_lower", all.x = TRUE)
+
+    if (any(is.na(gcMeta$species_id))) stop(
+      "gcMeta contains species name(s) not found in species_tr: ",
+      paste(shQuote(unique(subset(gcMeta, is.na(species_id))$name)), collapse = ", "))
+
+    sim$gcMeta <- gcMeta[, c(names(sim$gcMeta), "species_id"), with = FALSE]
+    data.table::setkey(sim$gcMeta, gcids)
+
+    rm(gcMeta)
+    rm(species_tr)
+
   }
-
-  speciesPixelGroup <- gcMeta[sim$species_tr, on = .(species = name)]
-  speciesPixelGroup <- speciesPixelGroup[gcids >= 1,]
-  speciesPixelGroup <- speciesPixelGroup[,.(gcids, species_id)]
-  speciesPixelGroup <- speciesPixelGroup[sim$spatialDT, on = .(gcids=gcids)]
-  speciesPixelGroup <- unique(speciesPixelGroup[,.(pixelGroup, species_id)])
-  sim$speciesPixelGroup <- speciesPixelGroup
 
 
   ## Create sim$disturbanceMeta, sim$historicDMtype, and sim$lastPassDMtype ----
@@ -482,6 +505,37 @@ Init <- function(sim) {
 
   ## Read inputs ----
 
+  # Growth and yield metadata
+  if (!suppliedElsewhere("gcMeta", sim)){
+
+    if (suppliedElsewhere("gcMetaURL", sim) &
+        !identical(sim$gcMetaURL, extractURL("gcMeta"))){
+
+      sim$gcMeta <- prepInputs(
+        destinationPath = inputPath(sim),
+        url = sim$gcMetaURL,
+        fun = data.table::fread
+      )
+
+    }else{
+
+      if (!suppliedElsewhere("gcMetaURL", sim, where = "user")) message(
+        "User has not supplied growth curve metadata ('gcMeta' or 'gcMetaURL'). ",
+        "Default for Saskatchewan will be used.")
+
+      sim$gcMeta <- prepInputs(
+        destinationPath = inputPath(sim),
+        url        = extractURL("gcMeta"),
+        targetFile = "gcMetaEg.csv",
+        fun        = data.table::fread
+      )
+
+      sim$gcMeta$sw_hw <- sapply(sim$gcMeta$forest_type_id == 1, ifelse, "sw", "hw")
+
+      data.table::setkey(sim$gcMeta, gcids)
+    }
+  }
+
   # Growth and yield table
   ## TODO add a data manipulation to adjust if the m3 are not given on a yearly basis.
   if (!suppliedElsewhere("userGcM3", sim)){
@@ -508,6 +562,8 @@ Init <- function(sim) {
         fun        = data.table::fread
       )
       names(sim$userGcM3) <- c("gcids", "Age", "MerchVolume")
+
+      data.table::setkeyv(sim$userGcM3, c("gcids", "Age"))
     }
   }
 

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -19,7 +19,7 @@ SpaDEStestSetGlobalOptions()
 spadesTestPaths <- SpaDEStestSetUpDirectories(require = "googledrive")
 
 
-## Download standard inputs that are usually provided by CBM_defaults or CBM_vol2biomass.
+## Download standard inputs that are usually provided by CBM_defaults.
 
 # Download CBM-CFS3 database usually provided by CBM_defaults
 if (!file.exists(file.path(spadesTestPaths$temp$inputs, "cbm_defaults_v1.2.8340.362.db"))){
@@ -30,14 +30,3 @@ if (!file.exists(file.path(spadesTestPaths$temp$inputs, "cbm_defaults_v1.2.8340.
     quiet    = TRUE
   )
 }
-
-# Download gcMetaEg usually provided by CBM_vol2biomass
-if (!file.exists(file.path(spadesTestPaths$temp$inputs, "gcMetaEg.csv"))){
-  withr::with_options(
-    c(googledrive_quiet = TRUE),
-    googledrive::drive_download(
-      "https://drive.google.com/file/d/189SFlySTt0Zs6k57-PzQMuQ29LmycDmJ",
-      path = file.path(spadesTestPaths$temp$inputs, "gcMetaEg.csv")
-    ))
-}
-

--- a/tests/testthat/test-1-module_1-defaults.R
+++ b/tests/testthat/test-1-module_1-defaults.R
@@ -34,8 +34,7 @@ test_that("Module runs with defaults", {
       spuLocator = sf::st_read(file.path(spadesTestPaths$testdata, "spuLocator.shp"), quiet = TRUE),
       dMatrixAssociation = read.csv(file.path(spadesTestPaths$testdata, "disturbance_matrix_association.csv")),
       spinupSQL  = read.csv(file.path(spadesTestPaths$testdata, "spinupSQL.csv")),
-      species_tr = read.csv(file.path(spadesTestPaths$testdata, "species_tr.csv")),
-      gcMeta     = read.csv(file.path(spadesTestPaths$temp$inputs, "gcMetaEg.csv"))
+      species_tr = read.csv(file.path(spadesTestPaths$testdata, "species_tr.csv"))
     )
   )
 
@@ -89,27 +88,34 @@ test_that("Module runs with defaults", {
   expect_true(is.factor(simTest$level3DT$gcids))
 
 
-  ## Check output 'speciesPixelGroup' ----
-
-  expect_true(!is.null(simTest$speciesPixelGroup))
-  expect_true(inherits(simTest$speciesPixelGroup, "data.table"))
-
-  for (colName in c("pixelGroup", "species_id")){
-    expect_true(colName %in% names(simTest$speciesPixelGroup))
-    expect_true(all(!is.na(simTest$speciesPixelGroup[[colName]])))
-  }
-
-  # Check that there is 1 for every pixel group
-  expect_equal(nrow(simTest$speciesPixelGroup), nrow(simTest$level3DT))
-  expect_equal(sort(simTest$speciesPixelGroup$pixelGroup), simTest$level3DT$pixelGroup)
-
-
   ## Check output 'curveID' ----
 
   expect_true(!is.null(simTest$curveID))
   expect_true(length(simTest$curveID) >= 1)
   expect_true("gcids" %in% simTest$curveID)
   expect_true(all(simTest$curveID %in% names(simTest$level3DT)))
+
+
+  ## Check output 'gcMeta' ----
+
+  expect_true(!is.null(simTest$gcMeta))
+  expect_true(inherits(simTest$gcMeta, "data.table"))
+
+  for (colName in c("gcids", "species_id", "sw_hw")){
+    expect_true(colName %in% names(simTest$gcMeta))
+    expect_true(all(!is.na(simTest$gcMeta[[colName]])))
+  }
+
+
+  ## Check output 'userGcM3' ----
+
+  expect_true(!is.null(simTest$userGcM3))
+  expect_true(inherits(simTest$userGcM3, "data.table"))
+
+  for (colName in c("gcids", "Age", "MerchVolume")){
+    expect_true(colName %in% names(simTest$userGcM3))
+    expect_true(all(!is.na(simTest$userGcM3[[colName]])))
+  }
 
 
   ## Check output 'ecozones' ----

--- a/tests/testthat/test-1-module_2-withAOI.R
+++ b/tests/testthat/test-1-module_2-withAOI.R
@@ -35,7 +35,6 @@ test_that("Module runs with study AOI", {
       dMatrixAssociation = read.csv(file.path(spadesTestPaths$testdata, "disturbance_matrix_association.csv")),
       spinupSQL  = read.csv(file.path(spadesTestPaths$testdata, "spinupSQL.csv")),
       species_tr = read.csv(file.path(spadesTestPaths$testdata, "species_tr.csv")),
-      gcMeta     = read.csv(file.path(spadesTestPaths$temp$inputs, "gcMetaEg.csv")),
 
       masterRaster = file.path(spadesTestPaths$testdata, "masterRaster-withAOI.tif"),
 
@@ -104,27 +103,34 @@ test_that("Module runs with study AOI", {
   expect_true(is.factor(simTest$level3DT$gcids))
 
 
-  ## Check output 'speciesPixelGroup' ----
-
-  expect_true(!is.null(simTest$speciesPixelGroup))
-  expect_true(inherits(simTest$speciesPixelGroup, "data.table"))
-
-  for (colName in c("pixelGroup", "species_id")){
-    expect_true(colName %in% names(simTest$speciesPixelGroup))
-    expect_true(all(!is.na(simTest$speciesPixelGroup[[colName]])))
-  }
-
-  # Check that there is 1 for every pixel group
-  expect_equal(nrow(simTest$speciesPixelGroup), nrow(simTest$level3DT))
-  expect_equal(sort(simTest$speciesPixelGroup$pixelGroup), simTest$level3DT$pixelGroup)
-
-
   ## Check output 'curveID' ----
 
   expect_true(!is.null(simTest$curveID))
   expect_true(length(simTest$curveID) >= 1)
   expect_true("gcids" %in% simTest$curveID)
   expect_true(all(simTest$curveID %in% names(simTest$level3DT)))
+
+
+  ## Check output 'gcMeta' ----
+
+  expect_true(!is.null(simTest$gcMeta))
+  expect_true(inherits(simTest$gcMeta, "data.table"))
+
+  for (colName in c("gcids", "species_id", "sw_hw")){
+    expect_true(colName %in% names(simTest$gcMeta))
+    expect_true(all(!is.na(simTest$gcMeta[[colName]])))
+  }
+
+
+  ## Check output 'userGcM3' ----
+
+  expect_true(!is.null(simTest$userGcM3))
+  expect_true(inherits(simTest$userGcM3, "data.table"))
+
+  for (colName in c("gcids", "Age", "MerchVolume")){
+    expect_true(colName %in% names(simTest$userGcM3))
+    expect_true(all(!is.na(simTest$userGcM3[[colName]])))
+  }
 
 
   ## Check output 'ecozones' ----


### PR DESCRIPTION
To be merged with: https://github.com/PredictiveEcology/CBM_core/pull/51

- gcMeta is now created with `species_id` and 'sw_hw' columns
- `speciesPixelGroup` table is no longer a a module output

