### PR TITLE
spatialDT now has an 'area' column

### DIFF
--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -135,6 +135,7 @@ defineModule(sim, list(
         "Required input to CBM_vol2biomass and CBM_core."),
       columns = c(
         pixelIndex      = "'masterRaster' cell index",
+        area            = "Stand area in meters",
         ages            = "Stand ages extracted from input 'ageRaster'",
         ageSpinup       = "Stand ages raised to minimum of age 3 to use in the spinup",
         spatial_unit_id = "Spatial unit IDs extracted from input 'spuLocator'",
@@ -276,7 +277,8 @@ Init <- function(sim) {
 
   # Create sim$allPixDT: Summarize input values into table
   allPixDT <- data.table::data.table(
-    pixelIndex = 1:terra::ncell(inRast$masterRaster)
+    pixelIndex = 1:terra::ncell(inRast$masterRaster),
+    area       = terra::values(terra::cellSize(inRast$masterRaster, unit = "m", mask = TRUE, transform = FALSE))[,1]
   )
   for (i in 1:length(pgCols)){
     allPixDT[[names(pgCols)[[i]]]] <- terra::values(inRast[[pgCols[[i]]]])[,1]

--- a/tests/testthat/test-2-multiModule_SK-small_1998-2000.R
+++ b/tests/testthat/test-2-multiModule_SK-small_1998-2000.R
@@ -102,7 +102,6 @@ test_that("Multi module: SK-small 1998-2000", {
       eventExpect = c(
         "init"              = times$start,
         "spinup"            = times$start,
-        "postSpinup"        = times$start,
         setNames(times$start:times$end, rep("annual", length(times$star:times$end))),
         "accumulateResults" = times$end
       )),

--- a/tests/testthat/test-2-multiModule_SK-small_1998-2000.R
+++ b/tests/testthat/test-2-multiModule_SK-small_1998-2000.R
@@ -117,15 +117,7 @@ test_that("Multi module: SK-small 1998-2000", {
 
   ## Check outputs ----
 
-  expect_true(!is.null(simTest$spinup_input))
-
   expect_true(!is.null(simTest$spinupResult))
-
-  expect_true(!is.null(simTest$cbm_vars))
-
-  expect_true(!is.null(simTest$pixelGroupC))
-
-  expect_true(!is.null(simTest$pixelKeep))
 
   expect_true(!is.null(simTest$cbmPools))
 


### PR DESCRIPTION
The `spatialDT$area` column will be used by `CBM_core` to calculation emissions totals instead of the master raster resolution.

The area is calculated using `terra::cellSize` so that the area is always in meters regardless of the raster CRS. This makes the module compatible with non-projected (lat-long) projections or any project where the resolution does not represent distance in meters.