### PR TITLE
adminLocator set to "Saskatchewan"

### DIFF
--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -70,6 +70,9 @@ defineModule(sim, list(
       objectName = "masterRaster", objectClass = "SpatRaster",
       desc = "Default `masterRaster` if not provided elsewhere by user."),
     createsOutput(
+      objectName = "adminLocator", objectClass = "character",
+      desc = "Administrative boundary name set to 'Saskatchewan'"),
+    createsOutput(
       objectName = "ageLocator", objectClass = "SpatRaster",
       desc = "Default `ageLocator` if not provided elsewhere by user."),
     createsOutput(
@@ -111,6 +114,9 @@ doEvent.CBM_dataPrep_SK <- function(sim, eventTime, eventType, debug = FALSE) {
 }
 
 Init <- function(sim){
+
+  # Set admin boundary name
+  sim$adminLocator <- "Saskatchewan"
 
   # Read Wulder and White disturbances rasters
   if (identical(sim$disturbanceRastersURL, extractURL("disturbanceRastersURL"))){

--- a/tests/testthat/test-1-module_1-defaults.R
+++ b/tests/testthat/test-1-module_1-defaults.R
@@ -47,6 +47,10 @@ test_that("Module runs with defaults", {
   expect_true(!is.null(simTest$masterRaster))
   expect_true(inherits(simTest$masterRaster, "SpatRaster"))
 
+  # adminLocator
+  expect_true(!is.null(simTest$adminLocator))
+  expect_equal(simTest$adminLocator, "Saskatchewan")
+
   # ageLocator
   expect_true(!is.null(simTest$ageLocator))
   expect_true(inherits(simTest$ageLocator, "SpatRaster"))

--- a/tests/testthat/test-1-module_2-withDisturbances.R
+++ b/tests/testthat/test-1-module_2-withDisturbances.R
@@ -52,6 +52,10 @@ test_that("Module runs with disturbances", {
   expect_true(!is.null(simTest$masterRaster))
   expect_true(inherits(simTest$masterRaster, "SpatRaster"))
 
+  # adminLocator
+  expect_true(!is.null(simTest$adminLocator))
+  expect_equal(simTest$adminLocator, "Saskatchewan")
+
   # ageLocator
   expect_true(!is.null(simTest$ageLocator))
   expect_true(inherits(simTest$ageLocator, "SpatRaster"))


### PR DESCRIPTION
Setting the location to "SK" deliberately which skips the use of the adminLocator Shapefile to set the location of the project. This same step is already in `CBM_dataPrep_RIA`.