### PR TITLE
Updated links to use files that cover all of SK

### DIFF
--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -46,7 +46,7 @@ defineModule(sim, list(
     expectsInput(
       objectName = "userGcMeta", objectClass = "data.table",
       desc = "Growth curve metadata.", #TODO: Define default data source
-      sourceURL = "https://drive.google.com/file/d/189SFlySTt0Zs6k57-PzQMuQ29LmycDmJ"),
+      sourceURL = "https://drive.google.com/file/d/1ugECJVNkglSSQFVqnk5ayG6q38l6AWe9"),
     expectsInput(
       objectName = "userGcM3", objectClass = "data.table",
       desc = "Growth curve volumes.", #TODO: Define default data source
@@ -60,7 +60,7 @@ defineModule(sim, list(
         "the disturbances will be processed into a list of `disturbanceRasters` for CBM_dataPrep")),
     expectsInput(
       objectName = "disturbanceMeta", objectClass = "data.table",
-      sourceURL = "https://drive.google.com/file/d/1ugECJVNkglSSQFVqnk5ayG6q38l6AWe9",
+      sourceURL = "https://drive.google.com/file/d/12z25mHl7McRm1ee7V7dgtSHdLP8-QEZp",
       desc = paste(
         "If the Wulder and White disturbance rasters are used,",
         "the metadata table describing their events is provided."))

--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -28,7 +28,7 @@ defineModule(sim, list(
     expectsInput(
       objectName = "masterRaster", objectClass = "SpatRaster",
       desc = "Raster template defining the study area. Default is a test area in the managed forests of SK.",
-      sourceURL = "https://drive.google.com/file/d/1zUyFH8k6Ef4c_GiWMInKbwAl6m6gvLJW"),
+      sourceURL = "https://drive.google.com/file/d/1FmtbEKbkzufIifETONxOkoplGX50lrT_"),
     expectsInput(
       objectName = "ageLocator", objectClass = "sf|SpatRaster",
       desc = "Spatial data source of stand ages. Default is the 2012 CASFRI inventory.",
@@ -42,7 +42,7 @@ defineModule(sim, list(
     expectsInput(
       objectName = "gcIndexLocator", objectClass = "sf|SpatRaster",
       desc = "Spatial data source of growth curve index locations.", #TODO: Define default data source
-      sourceURL = "https://drive.google.com/file/d/1yunkaYCV2LIdqej45C4F9ir5j1An0KKr"),
+      sourceURL = "https://drive.google.com/file/d/1TJHdzS85BLRMEvT1I2SjYsur-FZM4hmn/"),
     expectsInput(
       objectName = "userGcMeta", objectClass = "data.table",
       desc = "Growth curve metadata.", #TODO: Define default data source

--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -50,7 +50,7 @@ defineModule(sim, list(
     expectsInput(
       objectName = "userGcM3", objectClass = "data.table",
       desc = "Growth curve volumes.", #TODO: Define default data source
-      sourceURL = "https://drive.google.com/file/d/1u7o2BzPZ2Bo7hNcC8nEctNpDmp7ce84m"),
+      sourceURL = "https://drive.google.com/file/d/13s7fo5Ue5ji0aGYRQcJi-_wIb2-4bgVN"),
     expectsInput(
       objectName = "disturbanceRastersURL", objectClass = "character",
       sourceURL = "https://drive.google.com/file/d/1tsz57amfHjoLafGxjKYSWQPLD7HksdCa",
@@ -60,7 +60,7 @@ defineModule(sim, list(
         "the disturbances will be processed into a list of `disturbanceRasters` for CBM_dataPrep")),
     expectsInput(
       objectName = "disturbanceMeta", objectClass = "data.table",
-      sourceURL = "https://drive.google.com/file/d/12z25mHl7McRm1ee7V7dgtSHdLP8-QEZp",
+      sourceURL = "https://drive.google.com/file/d/1ugECJVNkglSSQFVqnk5ayG6q38l6AWe9",
       desc = paste(
         "If the Wulder and White disturbance rasters are used,",
         "the metadata table describing their events is provided."))

--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -119,17 +119,17 @@ Init <- function(sim){
     archiveDir <- prepInputs(
       destinationPath = inputPath(sim),
       url         = extractURL("disturbanceRastersURL"),
-      archive     = "disturbance_testArea.zip",
-      targetFile  = "disturbance_testArea",
+      archive     = "disturbance.zip",
+      targetFile  = "disturbance",
       alsoExtract = do.call(c, lapply(1985:2011, function(simYear){
-        paste0("disturbance_testArea/SaskDist_", simYear, c(".grd", ".gri", ".tif"))
+        paste0("disturbance/dist", simYear, c(".tif"))
       })),
       fun = NA)
 
     # Prepare files by year
-    grdFiles <- list.files(archiveDir, pattern = "\\.grd$", recursive = TRUE, full.names = TRUE)
-    grdYears <- sapply(strsplit(tools::file_path_sans_ext(basename(grdFiles)), "_"), `[[`, 2)
-    names(grdFiles) <- grdYears
+    grdFiles <- list.files(archiveDir, pattern = "\\.tif$", recursive = TRUE, full.names = TRUE)
+    # grdYears <- sapply(strsplit(tools::file_path_sans_ext(basename(grdFiles)), "_"), `[[`, 2)
+    # names(grdFiles) <- grdYears
 
     # Set disturbanceRasters list
     sim$disturbanceRasters <- c(
@@ -170,7 +170,7 @@ Init <- function(sim){
     sim$ageLocator <- prepInputs(
       destinationPath = inputPath(sim),
       url        = extractURL("ageLocator"),
-      targetFile = "age_TestArea.tif",
+      targetFile = "age1CASFRI.tif",
       fun        = terra::rast
     )
 

--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -53,7 +53,7 @@ defineModule(sim, list(
       sourceURL = "https://drive.google.com/file/d/1u7o2BzPZ2Bo7hNcC8nEctNpDmp7ce84m"),
     expectsInput(
       objectName = "disturbanceRastersURL", objectClass = "character",
-      sourceURL = "https://drive.google.com/file/d/12YnuQYytjcBej0_kdodLchPg7z9LygCt",
+      sourceURL = "https://drive.google.com/file/d/1tsz57amfHjoLafGxjKYSWQPLD7HksdCa",
       desc = paste(
         "The sourceURL is the Wulder and White disturbance rasters for SK covering 1984-2011.",
         "If this URL is provided by the user,",

--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -32,7 +32,7 @@ defineModule(sim, list(
     expectsInput(
       objectName = "ageLocator", objectClass = "sf|SpatRaster",
       desc = "Spatial data source of stand ages. Default is the 2012 CASFRI inventory.",
-      sourceURL = "https://drive.google.com/file/d/1hylk0D1vO19Dpg4zFtnSNhnyYP4j-bEA"),
+      sourceURL = "https://drive.google.com/file/d/1BV7_LI0hEc8g5AhKe5pfycrdWnVh_G4a"),
     expectsInput(
       objectName = "ageDataYear", objectClass = "numeric",
       desc = "Year that the ages in `ageLocator` represent."),

--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -70,6 +70,9 @@ defineModule(sim, list(
       objectName = "masterRaster", objectClass = "SpatRaster",
       desc = "Default `masterRaster` if not provided elsewhere by user."),
     createsOutput(
+      objectName = "adminLocator", objectClass = "character",
+      desc = "Administrative boundary name set to 'Saskatchewan'"),
+    createsOutput(
       objectName = "ageLocator", objectClass = "SpatRaster",
       desc = "Default `ageLocator` if not provided elsewhere by user."),
     createsOutput(
@@ -111,6 +114,9 @@ doEvent.CBM_dataPrep_SK <- function(sim, eventTime, eventType, debug = FALSE) {
 }
 
 Init <- function(sim){
+
+  # Set admin boundary name
+  sim$adminLocator <- "Saskatchewan"
 
   # Read Wulder and White disturbances rasters
   if (identical(sim$disturbanceRastersURL, extractURL("disturbanceRastersURL"))){


### PR DESCRIPTION
Most of the changes here are changing links from using files for the small test area to those that cover all of SK.

There are also a couple of changes to accommodate using the new disturbance rasters which are now .tifs instead of .grds and have slightly different names than the previous iteration. These are not permanent as most of this code will be changed anyway when we pick and go through whichever option we end up on for dealing with these disturbance layers. 