### PR TITLE
disturbance_testArea rasters URL added back in

### DIFF
--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -53,7 +53,7 @@ defineModule(sim, list(
       sourceURL = "https://drive.google.com/file/d/13s7fo5Ue5ji0aGYRQcJi-_wIb2-4bgVN"),
     expectsInput(
       objectName = "disturbanceRastersURL", objectClass = "character",
-      sourceURL = "https://drive.google.com/file/d/1tsz57amfHjoLafGxjKYSWQPLD7HksdCa",
+      sourceURL = "https://drive.google.com/file/d/12YnuQYytjcBej0_kdodLchPg7z9LygCt",
       desc = paste(
         "The sourceURL is the Wulder and White disturbance rasters for SK covering 1984-2011.",
         "If this URL is provided by the user,",
@@ -125,17 +125,17 @@ Init <- function(sim){
     archiveDir <- prepInputs(
       destinationPath = inputPath(sim),
       url         = extractURL("disturbanceRastersURL"),
-      archive     = "disturbance.zip",
-      targetFile  = "disturbance",
+      archive     = "disturbance_testArea.zip",
+      targetFile  = "disturbance_testArea",
       alsoExtract = do.call(c, lapply(1985:2011, function(simYear){
-        paste0("disturbance/dist", simYear, c(".tif"))
+        paste0("disturbance_testArea/SaskDist_", simYear, c(".grd", ".gri", ".tif"))
       })),
       fun = NA)
 
     # Prepare files by year
-    grdFiles <- list.files(archiveDir, pattern = "\\.tif$", recursive = TRUE, full.names = TRUE)
-    # grdYears <- sapply(strsplit(tools::file_path_sans_ext(basename(grdFiles)), "_"), `[[`, 2)
-    # names(grdFiles) <- grdYears
+    grdFiles <- list.files(archiveDir, pattern = "\\.grd$", recursive = TRUE, full.names = TRUE)
+    grdYears <- sapply(strsplit(tools::file_path_sans_ext(basename(grdFiles)), "_"), `[[`, 2)
+    names(grdFiles) <- grdYears
 
     # Set disturbanceRasters list
     sim$disturbanceRasters <- c(


### PR DESCRIPTION
Suggesting that we revert this part of the code that optionally takes a disturbanceRastersURL back to recognizing the SK small "disturbance_testArea" rasters URL instead of the updated "all of SK" raster URL. As it stands, we can't use this new URL directly without involving the related Shapefile attributes somehow, and if we are pivoting to use the NTEMS disturbances instead (https://github.com/PredictiveEcology/CBM_dataPrep/pull/6), there's no longer the motivation to tackle the complexity of including this. This will allow us to still have an easy way to use the small test area disturbance rasters for tests or examples.

NOTE: The module is set up so that these rasters are not always read in by default - the user still needs to provide this URL for the module to go through the process of reading them in. This will allow us to instead set `disturbanceSource = "NTEMS"` in our spadesCBM projects for all of SK.