### PR TITLE
masterRaster created manually with terra::rast

### DIFF
--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -156,12 +156,12 @@ Init <- function(sim){
 
     sim$masterRaster <- terra::rast(
       crs  = "EPSG:3979",
-      ext  = c(
-        xmin = -1077673.4762, ymin = 108487.9315,
-        xmax =  -426673.4762, ymax = 971077.9315
-      ),
       res  = 30,
-      vals = 1L
+      vals = 1L,
+      xmin = -1077673.4762,
+      xmax =  -426673.4762,
+      ymin =   108487.9315,
+      ymax =   971077.9315
     )
   }
 

--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -27,8 +27,7 @@ defineModule(sim, list(
   inputObjects = bindrows(
     expectsInput(
       objectName = "masterRaster", objectClass = "SpatRaster",
-      desc = "Raster template defining the study area. Default is a test area in the managed forests of SK.",
-      sourceURL = "https://drive.google.com/file/d/1ip4VGdKjPhQjElxJjHkM_1BoVM2C_sXs"),
+      desc = "Raster template defining the study area. Default is a test area in the managed forests of SK."),
     expectsInput(
       objectName = "ageLocator", objectClass = "sf|SpatRaster",
       desc = "Spatial data source of stand ages. Default is the 2012 CASFRI inventory.",
@@ -155,11 +154,14 @@ Init <- function(sim){
     message("User has not supplied a master raster ('masterRaster' or 'masterRasterURL'). ",
             "Default for Saskatchewan will be used.")
 
-    sim$masterRaster <- prepInputs(
-      destinationPath = inputPath(sim),
-      url        = extractURL("masterRaster"),
-      targetFile = "casfri_dom2-Byte.tif",
-      fun        = terra::rast
+    sim$masterRaster <- terra::rast(
+      crs  = "EPSG:3979",
+      ext  = c(
+        xmin = -1077673.4762, ymin = 108487.9315,
+        xmax =  -426673.4762, ymax = 971077.9315
+      ),
+      res  = 30,
+      vals = 1L
     )
   }
 

--- a/tests/testthat/test-2-integration_1-dataPrep.R
+++ b/tests/testthat/test-2-integration_1-dataPrep.R
@@ -33,9 +33,12 @@ test_that("Integration: CBM_dataPrep: SK test area (SPU 28) 2012", {
       # Set study area
       masterRaster = terra::rast(
         crs  = "EPSG:3979",
-        ext  = c(xmin = -687696, xmax = -681036, ymin = 711955, ymax = 716183),
         res  = 30,
-        vals = 1L
+        vals = 1L,
+        xmin = -687696,
+        xmax = -681036,
+        ymin =  711955,
+        ymax =  716183
       ),
 
       # Set disturbances

--- a/tests/testthat/test-2-integration_1-dataPrep.R
+++ b/tests/testthat/test-2-integration_1-dataPrep.R
@@ -32,10 +32,10 @@ test_that("Integration: CBM_dataPrep: SK test area (SPU 28) 2012", {
 
       # Set study area
       masterRaster = terra::rast(
-        extent     = c(xmin = -687696, xmax = -681036, ymin = 711955, ymax = 716183),
-        resolution = 30,
-        crs        = "EPSG:3979",
-        vals       = 1
+        crs  = "EPSG:3979",
+        ext  = c(xmin = -687696, xmax = -681036, ymin = 711955, ymax = 716183),
+        res  = 30,
+        vals = 1L
       ),
 
       # Set disturbances

--- a/tests/testthat/test-2-integration_2-CBM_1-SPU-28.R
+++ b/tests/testthat/test-2-integration_2-CBM_1-SPU-28.R
@@ -35,10 +35,10 @@ test_that("Integration: CBM: SK test area (SPU 28) 2012", {
 
       # Set study area
       masterRaster = terra::rast(
-        crs        = "EPSG:3979",
-        extent     = c(xmin = -687696, xmax = -681036, ymin = 711955, ymax = 716183),
-        resolution = 30,
-        vals       = 1
+        crs  = "EPSG:3979",
+        ext  = c(xmin = -687696, xmax = -681036, ymin = 711955, ymax = 716183),
+        res  = 30,
+        vals = 1L
       )
     )
   )

--- a/tests/testthat/test-2-integration_2-CBM_2-SPU-27-28.R
+++ b/tests/testthat/test-2-integration_2-CBM_2-SPU-27-28.R
@@ -38,10 +38,10 @@ test_that("Integration: CBM: SK test area (SPU 27 & 28) 2012", {
 
       # Set study area
       masterRaster = terra::rast(
-        crs        = "EPSG:3979",
-        extent     = c(xmin = -710000, xmax = -640000, ymin = 690000, ymax = 760000),
-        resolution = 50,
-        vals       = 1
+        crs  = "EPSG:3979",
+        ext  = c(xmin = -710000, xmax = -640000, ymin = 690000, ymax = 760000),
+        res  = 50,
+        vals = 1
       )
     )
   )

--- a/tests/testthat/test-2-integration_2-CBM_2-SPU-27-28.R
+++ b/tests/testthat/test-2-integration_2-CBM_2-SPU-27-28.R
@@ -39,9 +39,12 @@ test_that("Integration: CBM: SK test area (SPU 27 & 28) 2012", {
       # Set study area
       masterRaster = terra::rast(
         crs  = "EPSG:3979",
-        ext  = c(xmin = -710000, xmax = -640000, ymin = 690000, ymax = 760000),
         res  = 50,
-        vals = 1
+        vals = 1L,
+        xmin = -710000,
+        xmax = -640000,
+        ymin =  690000,
+        ymax =  760000
       )
     )
   )


### PR DESCRIPTION
In this PR I recreate a copy of our default masterRaster using `terra::rast` instead of downloading it from Google Drive. The key difference is that in this update all the values are assigned to `1L` (or non-NA) so that all cells will be considered potentially valid for analysis until `CBM_dataPrep` summarizes the inputs and discards any cells (`cohortDT` rows) missing key values in the `age`, `curveID`, etc columns. This makes it so that the default masterRaster can be used more flexibly with different input data sources; it will always create cohorts for any pixels with data available.