### PR TITLE
gcIndexLocator replaced by spsLocator and prodLocator; userGcMeta and userGcM3 file source updated

### DIFF
--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -196,7 +196,7 @@ Init <- function(sim){
     levels(sim$spsLocator) <- data.frame(
       value = 1:7,
       #LandR = c("Abie_bal", "Popu_bal", "Pice_mar", "Pinu_ban", "Popu_tre", "Betu_pap", "Pice_gla"),
-      species = c("Balsam fir", "Balsam poplar", "Black spruce", "Jack pine", "Trembling aspen", "White birch", "White spruce")
+      species = c("Balsam fir", "Balsam poplar", "Black spruce", "Jack pine", "Trembling aspen", "Paper birch", "White spruce")
     )
   }
 

--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -43,17 +43,24 @@ defineModule(sim, list(
       objectName = "ageSpinupMin", objectClass = "numeric",
       desc = "Minimum age for cohorts during spinup."),
     expectsInput(
-      objectName = "gcIndexLocator", objectClass = "sf|SpatRaster",
-      desc = "Spatial data source of growth curve index locations.", #TODO: Define default data source
-      sourceURL = "https://drive.google.com/file/d/1RWzETOXk0IbIUkSFvbPm46MGaFHgcjEr"),
+      objectName = "spsLocator", objectClass = "sf|SpatRaster",
+      desc = "Spatial data source of cohort species locations.",
+      sourceURL = "https://drive.google.com/file/d/1wQwL595kkxseq9CtDKLvHQgJ8JxS8x-L"),
+    expectsInput(
+      objectName = "prodLocator", objectClass = "sf|SpatRaster",
+      desc = "Spatial data source of productivity class locations.",
+      sourceURL = "https://drive.google.com/file/d/14JfZm4sIxxKT5pxaEBE0Sf2HH10dOe_c"),
+    expectsInput(
+      objectName = "curveID", objectClass = "character",
+      desc = "Growth curve ID."),
     expectsInput(
       objectName = "userGcMeta", objectClass = "data.table",
       desc = "Growth curve metadata.", #TODO: Define default data source
-      sourceURL = "https://drive.google.com/file/d/1ugECJVNkglSSQFVqnk5ayG6q38l6AWe9"),
+      sourceURL = "https://drive.google.com/file/d/1rnBRxkvUj7whrVJ8vr9-IpjNTUTdQl-F"),
     expectsInput(
       objectName = "userGcM3", objectClass = "data.table",
       desc = "Growth curve volumes.", #TODO: Define default data source
-      sourceURL = "https://drive.google.com/file/d/13s7fo5Ue5ji0aGYRQcJi-_wIb2-4bgVN"),
+      sourceURL = "https://drive.google.com/file/d/1rnBRxkvUj7whrVJ8vr9-IpjNTUTdQl-F"),
     expectsInput(
       objectName = "disturbanceRastersURL", objectClass = "character",
       sourceURL = "https://drive.google.com/file/d/12YnuQYytjcBej0_kdodLchPg7z9LygCt",
@@ -85,17 +92,17 @@ defineModule(sim, list(
       objectName = "ageSpinupMin", objectClass = "integer",
       desc = "Default minimum age for cohorts during spinup is set to 3 if `ageLocator` not provided elsewhere by user."),
     createsOutput(
-      objectName = "gcIndexLocator", objectClass = "SpatRaster",
-      desc = "Default `gcIndexLocator` if not provided elsewhere by user."),
+      objectName = "cohortLocators", objectClass = "list",
+      desc = "List of cohort locators including `spsLocator` and `prodLocator`."),
+    createsOutput(
+      objectName = "curveID", objectClass = "character",
+      desc = "Default `userGcMeta` growth curve ID."),
     createsOutput(
       objectName = "userGcMeta", objectClass = "data.table",
       desc = "Default `userGcMeta` if not provided elsewhere by user."),
     createsOutput(
       objectName = "userGcM3", objectClass = "data.table",
       desc = "Default `userGcM3` if not provided elsewhere by user."),
-    createsOutput(
-      objectName = "curveID", objectClass = "character",
-      desc = "`gcIndexLocator`, `userGcMeta`, and `userGcM3` growth curve ID."),
     createsOutput(
       objectName = "disturbanceRasters", objectClass = "list",
       desc = "The Wulder and White disturbance rasters if they are used."),
@@ -117,6 +124,12 @@ doEvent.CBM_dataPrep_SK <- function(sim, eventTime, eventType, debug = FALSE) {
 }
 
 Init <- function(sim){
+
+  # Set cohort locators
+  sim$cohortLocators <- c(sim$cohortLocators, list(
+    species   = sim$spsLocator,
+    prodClass = sim$prodLocator
+  ))
 
   # Read Wulder and White disturbances rasters
   if (identical(sim$disturbanceRastersURL, extractURL("disturbanceRastersURL"))){
@@ -169,6 +182,24 @@ Init <- function(sim){
     )
   }
 
+  # Cohort species
+  if (!suppliedElsewhere("spsLocator")){
+
+    sim$spsLocator <- prepInputs(
+      destinationPath = inputPath(sim),
+      url        = extractURL("spsLocator"),
+      targetFile = "casfri_dom2-Byte.tif",
+      fun        = terra::rast
+    )
+
+    # Source: https://drive.google.com/file/d/1w_qoT87TwjClWLz8sheBEzrNoPYrGpN6
+    levels(sim$spsLocator) <- data.frame(
+      value = 1:7,
+      #LandR = c("Abie_bal", "Popu_bal", "Pice_mar", "Pinu_ban", "Popu_tre", "Betu_pap", "Pice_gla"),
+      species = c("Balsam fir", "Balsam poplar", "Black spruce", "Jack pine", "Trembling aspen", "White birch", "White spruce")
+    )
+  }
+
   # Cohort ages
   if (!any(sapply(c("ageLocator", "ageLocatorURL"), suppliedElsewhere, sim))){
 
@@ -185,50 +216,74 @@ Init <- function(sim){
     sim$ageSpinupMin <- 3
   }
 
-  # Growth curve locations
-  if (!any(sapply(c("gcIndexLocator", "gcIndexLocatorURL"), suppliedElsewhere, sim))){
+  # Cohort growth curves
+  if (!suppliedElsewhere("userGcMeta", sim) & !suppliedElsewhere("userGcM3", sim)){
 
-    message("User has not supplied growth curve locations ('gcIndexLocator' or 'gcIndexLocatorURL'). ",
+    message("User has not supplied growth curves ('userGcMeta' and 'userGcM3'). ",
             "Default for Saskatchewan will be used.")
 
-    sim$gcIndexLocator <- prepInputs(
-      destinationPath = inputPath(sim),
-      url        = extractURL("gcIndexLocator"),
-      targetFile = "gcIndex-Byte.tif",
-      fun        = terra::rast
-    )
-  }
+    # Set curveID columns
+    if (!suppliedElsewhere("curveID", sim)) sim$curveID <- c("species", "prodClass")
 
-  # Growth curve metadata
-  if (!any(sapply(c("userGcMeta", "userGcMetaURL"), suppliedElsewhere, sim))){
-
-    message("User has not supplied growth curve metadata ('userGcMeta' or 'userGcMetaURL'). ",
-            "Default for Saskatchewan will be used.")
-
-    sim$userGcMeta <- prepInputs(
-      destinationPath = inputPath(sim),
-      url        = extractURL("userGcMeta"),
-      targetFile = "gcMetaEg.csv",
-      fun        = data.table::fread
-    )
-    data.table::setnames(sim$userGcMeta, names(sim$userGcMeta)[[1]], "curveID")
-    data.table::setkey(sim$userGcMeta, curveID)
-  }
-
-  # Growth curve volumes
-  if (!any(sapply(c("userGcM3", "userGcM3URL"), suppliedElsewhere, sim))){
-
-    message("User has not supplied growth curve volumes ('userGcM3' or 'userGcM3URL'). ",
-            "Default for Saskatchewan will be used.")
-
-    sim$userGcM3 <- prepInputs(
+    # Read growth curves from CSV
+    yieldTbl <- prepInputs(
       destinationPath = inputPath(sim),
       url        = extractURL("userGcM3"),
-      targetFile = "userGcM3.csv",
+      targetFile = "yield_1_7.csv",
       fun        = data.table::fread
-    )
-    data.table::setnames(sim$userGcM3, names(sim$userGcM3), c("curveID", "Age", "MerchVolume"))
-    data.table::setkeyv(sim$userGcM3, c("curveID", "Age"))
+    ) |> subset(ForestDistrict == "Saskatchewan" & !is.na(prodClass))
+
+    # Create unique curve ID
+    yieldTbl[, curveID := .GRP, by = eval(paste0("Age", 0:250))]
+
+    if (!suppliedElsewhere("userGcMeta", sim)){
+
+      sim$userGcMeta <- unique(yieldTbl[, .(species = Species, prodClass, curveID)])
+      data.table::setkey(sim$userGcMeta, species, prodClass)
+
+      sim$userGcMeta[species == "Unspecified conifers - Genus type", species := "Coniferous"]
+
+      # Save to outputs directory
+      outCSV <- file.path(outputPath(sim), "CBM_dataPrep_SK", "userGcMeta.csv")
+      dir.create(dirname(outCSV), recursive = TRUE, showWarnings = FALSE)
+      data.table::fwrite(sim$userGcMeta, outCSV)
+    }
+
+    if (!suppliedElsewhere("userGcM3", sim)){
+
+      sim$userGcM3 <- data.table::rbindlist(apply(
+        unique(yieldTbl[, .SD, .SDcols = c("curveID", paste0("Age", 0:250))]),
+        1, function(r){
+        data.table::data.table(
+          curveID     = r[["curveID"]],
+          Age         = 0:250,
+          MerchVolume = r[paste0("Age", 0:250)]
+        )
+      }, simplify = FALSE))
+      data.table::setkey(sim$userGcM3, curveID, Age)
+
+      # Save to outputs directory
+      outCSV <- file.path(outputPath(sim), "CBM_dataPrep_SK", "userGcM3.csv")
+      dir.create(dirname(outCSV), recursive = TRUE, showWarnings = FALSE)
+      data.table::fwrite(sim$userGcM3, outCSV)
+    }
+
+    # Site productivity
+    if (!suppliedElsewhere("prodLocator")){
+
+      sim$prodLocator <- prepInputs(
+        destinationPath = inputPath(sim),
+        url        = extractURL("prodLocator"),
+        targetFile = "site_productivity.tif",
+        fun        = terra::rast
+      )
+
+      # Source: https://drive.google.com/file/d/1fMpm2m-oaLFjfZLsxOIKz2KDr7II_QiV
+      levels(sim$prodLocator) <- data.frame(
+        value = 0:3,
+        prodClass = c(NA, "G", "M", "P")
+      )
+    }
   }
 
   # Disturbance metadata

--- a/tests/testthat/test-1-module_1-defaults.R
+++ b/tests/testthat/test-1-module_1-defaults.R
@@ -63,9 +63,13 @@ test_that("Module: defaults", {
   expect_true(!is.null(simTest$ageSpinupMin))
   expect_true(inherits(simTest$ageSpinupMin, "numeric"))
 
-  # gcIndexLocator
-  expect_true(!is.null(simTest$gcIndexLocator))
-  expect_true(inherits(simTest$gcIndexLocator, "SpatRaster"))
+  # spsLocator
+  expect_true(!is.null(simTest$spsLocator))
+  expect_true(inherits(simTest$spsLocator, "SpatRaster"))
+
+  # prodLocator
+  expect_true(!is.null(simTest$prodLocator))
+  expect_true(inherits(simTest$prodLocator, "SpatRaster"))
 
   # userGcMeta
   expect_true(!is.null(simTest$userGcMeta))

--- a/tests/testthat/test-1-module_2-withDisturbances.R
+++ b/tests/testthat/test-1-module_2-withDisturbances.R
@@ -65,9 +65,13 @@ test_that("Module: with example disturbances", {
   expect_true(!is.null(simTest$ageSpinupMin))
   expect_true(inherits(simTest$ageSpinupMin, "numeric"))
 
-  # gcIndexLocator
-  expect_true(!is.null(simTest$gcIndexLocator))
-  expect_true(inherits(simTest$gcIndexLocator, "SpatRaster"))
+  # spsLocator
+  expect_true(!is.null(simTest$spsLocator))
+  expect_true(inherits(simTest$spsLocator, "SpatRaster"))
+
+  # prodLocator
+  expect_true(!is.null(simTest$prodLocator))
+  expect_true(inherits(simTest$prodLocator, "SpatRaster"))
 
   # userGcMeta
   expect_true(!is.null(simTest$userGcMeta))

--- a/tests/testthat/test-2-integration_1-dataPrep.R
+++ b/tests/testthat/test-2-integration_1-dataPrep.R
@@ -73,7 +73,7 @@ test_that("Integration: CBM_dataPrep: SK test area (SPU 28) 2012", {
   expect_identical(data.table::key(simTest$standDT), "pixelIndex")
 
   # Check number of valid pixels (no NAs in any column)
-  expect_equal(nrow(simTest$standDT), 6751)
+  expect_equal(nrow(simTest$standDT), 6753)
 
   # Check spatial units
   expect_equal(sort(unique(simTest$standDT$spatial_unit_id)), 28)
@@ -101,6 +101,12 @@ test_that("Integration: CBM_dataPrep: SK test area (SPU 28) 2012", {
   expect_equal(nrow(simTest$cohortDT), nrow(simTest$standDT))
 
 
+  ## Check output 'curveID' ----
+
+  expect_true(!is.null(simTest$curveID))
+  expect_equal(simTest$curveID, c("species", "prodClass"))
+
+
   ## Check output 'userGcMeta' ----
 
   expect_true(!is.null(simTest$userGcMeta))
@@ -117,7 +123,7 @@ test_that("Integration: CBM_dataPrep: SK test area (SPU 28) 2012", {
   expect_true(!is.null(simTest$userGcM3))
   expect_true(inherits(simTest$userGcM3, "data.table"))
 
-  for (colName in c(simTest$curveID, "Age", "MerchVolume")){
+  for (colName in c("curveID", "Age", "MerchVolume")){
     expect_true(colName %in% names(simTest$userGcM3))
     expect_true(all(!is.na(simTest$userGcM3[[colName]])))
   }


### PR DESCRIPTION
This update replaces the need for a `gcIndexRaster` with a species layer (`spsLocator`) and and site productivity layer (`prodLocator`). This will allow us to easily swap data sources to run simulations in SK as long as we have a species layer we can use.

`spsLocator` has been set by default to the [casfri_dom2-Byte.tif](https://drive.google.com/file/d/1wQwL595kkxseq9CtDKLvHQgJ8JxS8x-L) raster in [SK_30m](https://drive.google.com/drive/folders/1gnsELctp-DWMIdvorGl1IElxKD5hiF-9) containing 7 species. `prodLocator` has been set by default to the [site_productivity.tif](https://drive.google.com/file/d/14JfZm4sIxxKT5pxaEBE0Sf2HH10dOe_c) raster in [SK_30m/11_CASFRI/layers](https://drive.google.com/drive/folders/1_4WSRWS9-Q2FTyFQV4RfTo028VwPALQ0) containing 3 productivity classes (and NA).

In order to make this work, it was necessary to update our `userGcMeta` table to include a `prodClass` column to match our `cohortDT` table with. At first, I figured it would make sense to find this information in the curve source data somewhere and add it to our existing tables. However, after @camillegiuliano showed me the `yield_1_7.csv` CSV file from which these tables were built, I decided to try another approach. In an effort to be as reproducible as possible, I've made use of this "raw" CSV source of the SK growth curves to create both the `userGcMeta` and `userGcM3` tables on the fly. 

I found a few identical copies of this table on Google Drive but am using [yield_1_7.csv](https://drive.google.com/file/d/1rnBRxkvUj7whrVJ8vr9-IpjNTUTdQl-F) located in directory [SK_30m/11_CASFRI/finalInput/LookupTables](https://drive.google.com/drive/folders/1RF42ZV6NvhzIKnyjJ25p96T7xEyAOxni). @cboisvenue if there's a better or more original source for this data let me know.

`.inputObjects` creates both the `userGcMeta` and `userGcM3` objects from this table by splitting the curve metadata and the curve volumes into 2 tables. `userGcM3` now only has 10 curves total: one for each *unique* growth curve in `yield_1_7.csv`. These IDs are assigned OTF with values `1:10`.

`userGcMeta` has 3 columns: 

1. `species`: Species name (e.g. `Balsam fir`)
2. `prodClass`: Site productivity class (one of `c(NA, "G", "M", "P")`)
3. `curveID`: One of the `curveID` in `userGcMeta`; this is not unique to every combo of `species` and `prodClass`.

This reduces the total number of curves in `userGcM3` from 42 to the original 10 because the input curves are no longer duplicated for every unique combination of species, productivity class, and spatial_unit_id in SK. Instead, **CBM_vol2biomass_SK** takes this smaller set of these curves and creates unique increments with these parameters.

I've included a step where the `userGcMeta` and `userGcM3` tables are saved to CSV in the simulation outputs directory in case it's still useful to review them in that familiar format.

@camillegiuliano this will still work with a `gcIndexRaster` if you set your input in your project as `cohortLocators = list(curveID =gcIndexRaster))`. If it would be more convenient to allow the used to provide a `gcIndexRaster` directly to this module it wouldn't be hard to accommodate that.

This will have to pair with an update to **CBM_vol2biomass_SK** where the special steps for handling the paper birch curves works with these new tables. I can make this PR ready for review once that is merged.