### PR TITLE
ageBacktrackSplit set by module

### DIFF
--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -87,6 +87,9 @@ defineModule(sim, list(
       objectName = "ageDataYear", objectClass = "integer",
       desc = "Data year of default `ageLocator` if not provided elsewhere by user."),
     createsOutput(
+      objectName = "ageBacktrackSplit", objectClass = "character",
+      desc = "Default `ageBacktrackSplit` if not provided elsewhere by user."),
+    createsOutput(
       objectName = "ageSpinupMin", objectClass = "integer",
       desc = "Default minimum age for cohorts during spinup is set to 3 if `ageLocator` not provided elsewhere by user."),
     createsOutput(
@@ -147,6 +150,12 @@ PrepCohortData <- function(sim){
     cohortData$LandR <- SCANFImatchSpeciesToCurves(
       sim$masterRaster, spsMatch = spsMatch
     ) |> Cache()
+
+    # Split age backtracking by forest type
+    if (identical(sim$ageLocator, "SCANFI-2020-age") & is.null(sim$ageBacktrackSplit)){
+
+      sim$ageBacktrackSplit <- "sw_hw"
+    }
 
   }else if (!is.null(sim$spsLocator)){
 

--- a/tests/testthat/test-1-module_3-SCANFI.R
+++ b/tests/testthat/test-1-module_3-SCANFI.R
@@ -82,5 +82,9 @@ test_that("Module: SCANFI 2020 data", {
       val = c(0:7),
       N   = c(4477, 4, 97, 23727, 59, 1900, 773, 629)
     ), tolerance = 10, scale = 1)
+
+  # Age backtracking
+  expect_equal(simTest$ageBacktrackSplit, "sw_hw")
+
 })
 


### PR DESCRIPTION
This sets the `ageBacktrackSplit` value to `sw_hw` so that the ages filled in with the age backtracking is split by SW vs. HW.