### PR TITLE
Parallel processing introduced for SCANFImatchSpeciesToCurves

### DIFF
--- a/CBM_dataPrep_SK.R
+++ b/CBM_dataPrep_SK.R
@@ -23,6 +23,8 @@ defineModule(sim, list(
     "PredictiveEcology/CBMutils@development (>=2.3.2)"
   ),
   parameters = rbind(
+    defineParameter("parallel.cores",    "integer", NA,   NA, NA, "Number of cores to use in parallel processing"),
+    defineParameter("parallel.tileSize", "integer", 2500, NA, NA, "Raster tile size when using parallel processing"),
     defineParameter(".useCache", "character", ".inputObjects", NA, NA, "Cache module events")
   ),
   inputObjects = bindrows(
@@ -148,8 +150,10 @@ PrepCohortData <- function(sim){
 
     # Map SCANFI species to SK curves
     cohortData$LandR <- SCANFImatchSpeciesToCurves(
-      sim$masterRaster, spsMatch = spsMatch
-    ) |> Cache()
+      sim$masterRaster, spsMatch = spsMatch,
+      parallel.cores    = P(sim)$parallel.cores,
+      parallel.tileSize = P(sim)$parallel.tileSize
+    ) |> Cache(omitArgs = c("parallel.cores", "parallel.tileSize"))
 
     # Split age backtracking by forest type
     if (identical(sim$ageLocator, "SCANFI-2020-age") & is.null(sim$ageBacktrackSplit)){

--- a/R/SCANFI-species.R
+++ b/R/SCANFI-species.R
@@ -1,7 +1,9 @@
 
 # Map SCANFI species to SK curves
-SCANFImatchSpeciesToCurves <- function(masterRaster, spsMatch, spsRast = NULL,
-                                       inputDir = getOption("spades.inputPath", ".")){
+SCANFImatchSpeciesToCurves <- function(
+    masterRaster, spsMatch, spsRast = NULL,
+    parallel.cores = NULL, parallel.tileSize = 2500,
+    inputDir = getOption("spades.inputPath", ".")){
 
   if (is.null(spsRast)){
     message("SCANFI species: reading species layers")
@@ -9,8 +11,16 @@ SCANFImatchSpeciesToCurves <- function(masterRaster, spsMatch, spsRast = NULL,
       "SCANFI-2020-LandR", inputPath = inputDir, verbose = -1)$source
   }
 
-  message("SCANFI species: cropping data to study area")
+  message("SCANFI species: reading species table")
+  spsNames <- names(spsRast)
 
+  spsMatch <- data.table::as.data.table(spsMatch)
+  spsMatch[, id := match(curve, unique(spsMatch$curve))]
+  spsMatch[, intersect(spsNames, names(spsMatch)) := lapply(.SD, as.logical),
+           .SDcols = intersect(spsNames, names(spsMatch))]
+  spsMatch[,   setdiff(spsNames, names(spsMatch)) := FALSE]
+
+  message("SCANFI species: reading study area bounds")
   adminMask <- sf::st_intersection(
     CBMutils::CBMsourcePrepInputs(
       "StatCan-admin", inputPath = inputDir, verbose = -1)$source |>
@@ -22,44 +32,104 @@ SCANFImatchSpeciesToCurves <- function(masterRaster, spsMatch, spsRast = NULL,
       sf::st_segmentize(10000) |>
       sf::st_transform(sf::st_crs(spsRast))
   )
-  spsRast <- terra::crop(spsRast, adminMask, mask = FALSE, snap = "out")
 
-  message("SCANFI species: extracting leading species")
+  spsOut <- terra::crop(terra::rast(
+    ext = terra::ext(spsRast),
+    crs = terra::crs(spsRast),
+    res = terra::res(spsRast)
+  ), adminMask, snap = "out")
 
-  spsNames <- names(spsRast)
+  if (is.null(parallel.cores) || is.na(parallel.cores)){
 
-  spsMax <- terra::app(spsRast, "max")
-  spsMax <- terra::mask(spsMax, terra::vect(adminMask))
-  spsMax <- terra::classify(spsMax, cbind(0, NA))
+    message("SCANFI species: cropping data to study area")
 
-  cellIdx <- terra::cells(spsMax)
+    spsRast <- terra::crop(spsRast, adminMask, mask = FALSE, snap = "out")
 
-  spsRast <- data.table::data.table(terra::extract(spsRast, cellIdx))
-  spsRast[, max := terra::extract(spsMax, cellIdx)]
-  spsRast[, (spsNames) := lapply(.SD, `==`, max), .SDcols = spsNames]
-  spsRast[, max := NULL]
+    message("SCANFI species: extracting leading species")
 
-  message("SCANFI species: matching leading species to SK curves")
+    spsMax <- terra::app(spsRast, "max")
+    spsMax <- terra::mask(spsMax, terra::vect(adminMask))
+    spsMax <- terra::classify(spsMax, cbind(0, NA))
 
-  spsMatch[, id := match(curve, unique(spsMatch$curve))]
-  spsMatch[, intersect(spsNames, names(spsMatch)) := lapply(.SD, as.logical),
-           .SDcols = intersect(spsNames, names(spsMatch))]
-  spsMatch[,   setdiff(spsNames, names(spsMatch)) := FALSE]
-  spsRast <- data.table::merge.data.table(
-    spsRast, spsMatch, by = spsNames, all.x = TRUE, sort = FALSE
-  )
+    cellIdx <- terra::cells(spsMax)
 
-  if (any(is.na(spsRast$id))){
-    notFound <- unique(spsRast[is.na(id), .SD, .SDcols = spsNames])
-    stop("SCANFI leading species combination(s) have not been assigned a curve: ",
-         paste(shQuote(apply(notFound, 1, function(r) paste(names(r)[r], collapse = ";"))),
-               collapse = ", "))
+    spsIDs <- data.table::data.table(terra::extract(spsRast, cellIdx))
+    spsIDs[, cellIdx := cellIdx]
+    rm(cellIdx)
+
+    spsIDs[, max := terra::extract(spsMax, cellIdx)]
+    rm(spsMax)
+
+    spsIDs[, (spsNames) := lapply(.SD, `==`, max), .SDcols = spsNames]
+    spsIDs[, max := NULL]
+
+    message("SCANFI species: matching leading species to SK curves")
+
+    spsIDs <- data.table::merge.data.table(spsIDs, spsMatch, by = spsNames, all.x = TRUE)
+
+    if (any(is.na(spsIDs$id))){
+      notFound <- unique(spsIDs[is.na(id), .SD, .SDcols = spsNames])
+      stop("SCANFI leading species combination(s) have not been assigned a curve: ",
+           paste(shQuote(apply(notFound, 1, function(r) paste(names(r)[r], collapse = ";"))),
+                 collapse = ", "))
+    }
+
+    spsIDs[, setdiff(c("cellIdx", "id"), names(spsIDs)) := NULL]
+
+  }else{
+
+    tileExt <- terra::getTileExtents(spsOut, parallel.tileSize)
+
+    message("SCANFI species: reading leading species in ", nrow(tileExt), " tiles")
+
+    spsRastFiles <- terra::sources(spsRast)
+    names(spsRastFiles) <- names(spsRast)
+
+    spsRast <- terra::rast(spsRastFiles[[1]])
+
+    spsIDs <- data.table::rbindlist(parallel::mclapply(
+      lapply(1:nrow(tileExt), function(i){
+        terra::cells(spsRast, terra::vect(sf::st_crop(adminMask, tileExt[i,])), touches = FALSE)[,2]
+      }),
+      mc.cores = parallel.cores,
+      function(cellIdx){
+
+        s <- data.table::as.data.table(lapply(spsRastFiles, function(f){
+          terra::extract(terra::rast(f), cellIdx)
+        }))
+
+        s[, max := apply(s, 1, max)]
+        s[, cellIdx := cellIdx]
+        rm(cellIdx)
+
+        s <- s[max > 0,]
+        if (nrow(s) > 0){
+
+          s[, (spsNames) := lapply(.SD, `==`, max), .SDcols = spsNames]
+          s[, max := NULL]
+          s <- data.table::merge.data.table(s, spsMatch, by = spsNames, all.x = TRUE)
+
+          if (any(is.na(s$id))){
+            notFound <- unique(s[is.na(id), .SD, .SDcols = spsNames])
+            stop("SCANFI leading species combination(s) have not been assigned a curve: ",
+                 paste(shQuote(apply(notFound, 1, function(r) paste(names(r)[r], collapse = ";"))),
+                       collapse = ", "))
+          }
+        }else s[, id := numeric(0)]
+
+        s[, .(cellIdx, id)]
+      }))
+
+    spsIDs[, cellIdx := terra::cellFromXY(spsOut, terra::xyFromCell(spsRast, cellIdx))]
   }
 
-  spsRast <- spsRast$id
-  terra::values(spsMax) <- 0
-  terra::set.values(spsMax, cellIdx, spsRast)
-  levels(spsMax) <- rbind(cbind(id = 0, curve = NA), unique(spsMatch[, .(id, curve)]))
-  spsMax
+  message("SCANFI species: returning leading species")
+
+  terra::values(spsOut) <- 0L
+  terra::set.values(spsOut, spsIDs$cellIdx, spsIDs$id)
+  levels(spsOut) <- rbind(cbind(id = 0, curve = NA), unique(spsMatch[, .(id, curve)]))
+  return(spsOut)
 }
+
+
 

--- a/tests/testthat/test-1-module_3-SCANFI.R
+++ b/tests/testthat/test-1-module_3-SCANFI.R
@@ -83,8 +83,5 @@ test_that("Module: SCANFI 2020 data", {
       N   = c(4477, 4, 97, 23727, 59, 1900, 773, 629)
     ), tolerance = 10, scale = 1)
 
-  # Age backtracking
-  expect_equal(simTest$ageBacktrackSplit, "sw_hw")
-
 })
 


### PR DESCRIPTION
This allows the user to set the `parallel.cores` and `parallel.tileSize` parameters to use parallel processing when reading the SCANFI species layers.